### PR TITLE
update parsers for new `ElectronicEigenvalues` implementation

### DIFF
--- a/src/nomad_simulation_parsers/schema_packages/exciting.py
+++ b/src/nomad_simulation_parsers/schema_packages/exciting.py
@@ -147,7 +147,7 @@ class TotalForce(properties.forces.TotalForce):
 
 class ElectronicEigenvalues(outputs.ElectronicEigenvalues):
     add_mapping_annotation(
-        outputs.ElectronicEigenvalues.n_bands, EIGVAL_KEY, '.n_states'
+        outputs.ElectronicEigenvalues.n_levels, EIGVAL_KEY, '.n_states'
     )
     add_mapping_annotation(
         outputs.ElectronicEigenvalues.value, EIGVAL_KEY, '.eigenvalues'
@@ -159,7 +159,7 @@ class ElectronicEigenvalues(outputs.ElectronicEigenvalues):
 
 class ElectronicBandStructure(outputs.ElectronicBandStructure):
     add_mapping_annotation(
-        outputs.ElectronicBandStructure.n_bands, BANDSTRUCTURE_XML_KEY, '.n_states'
+        outputs.ElectronicBandStructure.n_levels, BANDSTRUCTURE_XML_KEY, '.n_states'
     )
     add_mapping_annotation(
         outputs.ElectronicBandStructure.value, BANDSTRUCTURE_XML_KEY, '.energies'

--- a/src/nomad_simulation_parsers/schema_packages/exciting.py
+++ b/src/nomad_simulation_parsers/schema_packages/exciting.py
@@ -145,6 +145,7 @@ class TotalForce(properties.forces.TotalForce):
     add_mapping_annotation(properties.forces.TotalForce.value, INFO_KEY, '.forces')
 
 
+# TODO: check whether this section is k-dependent
 class ElectronicEigenvalues(outputs.ElectronicEigenvalues):
     add_mapping_annotation(
         outputs.ElectronicEigenvalues.n_levels, EIGVAL_KEY, '.n_states'

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -160,6 +160,7 @@ class TotalForce(properties.forces.TotalForce):
     add_mapping_annotation(properties.forces.TotalForce.value, TEXT_KEY, '.forces')
 
 
+# TODO: check whether this section is k-dependent
 class ElectronicEigenvalues(properties.ElectronicEigenvalues):
     add_mapping_annotation(
         properties.ElectronicEigenvalues.n_levels, TEXT_KEY, '.nbands'

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -162,7 +162,7 @@ class TotalForce(properties.forces.TotalForce):
 
 class ElectronicEigenvalues(properties.ElectronicEigenvalues):
     add_mapping_annotation(
-        properties.ElectronicEigenvalues.n_bands, TEXT_KEY, '.nbands'
+        properties.ElectronicEigenvalues.n_levels, TEXT_KEY, '.nbands'
     )
     add_mapping_annotation(
         properties.ElectronicEigenvalues.value, TEXT_KEY, '.eigenvalues'

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -244,6 +244,7 @@ class TotalForce(properties.forces.TotalForce):
     )
 
 
+# TODO: check whether this section is k-dependent
 class ElectronicEigenvalues(outputs.ElectronicEigenvalues):
     add_mapping_annotation(
         outputs.ElectronicEigenvalues.n_levels,

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -246,17 +246,17 @@ class TotalForce(properties.forces.TotalForce):
 
 class ElectronicEigenvalues(outputs.ElectronicEigenvalues):
     add_mapping_annotation(
-        outputs.ElectronicEigenvalues.n_bands,
+        outputs.ElectronicEigenvalues.n_levels,
         XML_KEY,
         'length(.array.set.set.set[0].r)',
     )
     add_mapping_annotation(
-        outputs.ElectronicEigenvalues.n_bands,
+        outputs.ElectronicEigenvalues.n_levels,
         XML2_KEY,
         'length(.array.set.set.set[0].r)',
     )
     add_mapping_annotation(
-        outputs.ElectronicEigenvalues.n_bands, OUTCAR_KEY, '.n_bands'
+        outputs.ElectronicEigenvalues.n_levels, OUTCAR_KEY, '.n_bands'
     )
 
     # TODO This only works for non-spin pol

--- a/src/nomad_simulation_parsers/schema_packages/wannier90.py
+++ b/src/nomad_simulation_parsers/schema_packages/wannier90.py
@@ -156,7 +156,7 @@ class Wannier(model_method.Wannier):
 
 class ElectronicBandStructure(properties.ElectronicBandStructure):
     add_mapping_annotation(
-        properties.ElectronicBandStructure.n_bands, WOUT_KEY, '.Nwannier'
+        properties.ElectronicBandStructure.n_levels, WOUT_KEY, '.Nwannier'
     )
     add_mapping_annotation(
         properties.ElectronicBandStructure.value, BAND_KEY, ('get_data', ['.data'])

--- a/src/nomad_simulation_parsers/schema_packages/wannier90.py
+++ b/src/nomad_simulation_parsers/schema_packages/wannier90.py
@@ -154,6 +154,7 @@ class Wannier(model_method.Wannier):
     # add_mapping_annotations(model_method.Wannier.n_orbitals, WOUT_KEY, '.Nwannier')
 
 
+# TODO: check whether this section is k-dependent
 class ElectronicBandStructure(properties.ElectronicBandStructure):
     add_mapping_annotation(
         properties.ElectronicBandStructure.n_levels, WOUT_KEY, '.Nwannier'


### PR DESCRIPTION
To reflect the minor changes in the schema under: https://github.com/nomad-coe/nomad-simulations/pull/280

As per discussion with @ndaelman-hu, i have also added TODOs for when ElectronicEigenvalues are populated, to check whether this implementation is working as intended

im ready to merge the schema PR whenever possible :+1: 