### PR TITLE
Fix usage of representation schema in mdparserutils

### DIFF
--- a/src/nomad_simulation_parsers/parsers/utils/mdparserutils.py
+++ b/src/nomad_simulation_parsers/parsers/utils/mdparserutils.py
@@ -29,7 +29,6 @@ from nomad_simulations.schema_packages import workflow
 from nomad_simulations.schema_packages.atoms_state import ParticleState
 from nomad_simulations.schema_packages.general import Simulation
 from nomad_simulations.schema_packages.model_system import (
-    AlternativeRepresentation,
     ModelSystem,
 )
 
@@ -148,7 +147,7 @@ class MDParser(ArchiveWriter):
         data: dict[str, Any],
         simulation: Simulation,
         model_system: ModelSystem = None,
-        representation: AlternativeRepresentation = None,
+        # representations: AlternativeRepresentation = None,
     ) -> None:
         """
         Create a system section and write the provided data.
@@ -160,8 +159,6 @@ class MDParser(ArchiveWriter):
             return
         if model_system is None:
             model_system = ModelSystem()
-        if representation is None:
-            representation = AlternativeRepresentation()
 
         lattice_vectors = data.pop('lattice_vectors')
         periodic_boundary_conditions = data.pop('periodic_boundary_conditions')
@@ -172,11 +169,8 @@ class MDParser(ArchiveWriter):
             particle_state = ParticleState(label=label)
             model_system.particle_states.append(particle_state)
 
-        q_lattice = model_system.m_get_quantity_definition('lattice_vectors')
-        model_system.m_set(q_lattice, lattice_vectors)
-
-        q_pbc = model_system.m_get_quantity_definition('periodic_boundary_conditions')
-        model_system.m_set(q_pbc, periodic_boundary_conditions)
+        model_system.lattice_vectors = lattice_vectors
+        model_system.periodic_boundary_conditions = periodic_boundary_conditions
 
         model_system.dimensionality = dimensions
 

--- a/src/nomad_simulation_parsers/parsers/utils/mdparserutils.py
+++ b/src/nomad_simulation_parsers/parsers/utils/mdparserutils.py
@@ -23,9 +23,15 @@ from typing import Any
 import numpy as np
 from nomad.parsing.file_parser import ArchiveWriter
 from nomad.utils import get_logger
+
+# from runschema.method import Interaction, Model
+from nomad_simulations.schema_packages import workflow
 from nomad_simulations.schema_packages.atoms_state import ParticleState
 from nomad_simulations.schema_packages.general import Simulation
-from nomad_simulations.schema_packages.model_system import ModelSystem, Representation
+from nomad_simulations.schema_packages.model_system import (
+    AlternativeRepresentation,
+    ModelSystem,
+)
 
 # nomad-simulations
 from nomad_simulations.schema_packages.outputs import (
@@ -37,9 +43,6 @@ from nomad_simulations.schema_packages.properties.energies import BaseEnergy
 from nomad_simulations.schema_packages.properties.forces import BaseForce
 
 # from runschema.method import Interaction, Model
-from nomad_simulations.schema_packages.workflow.molecular_dynamics import (
-    MolecularDynamics,
-)
 
 
 class MDParser(ArchiveWriter):
@@ -145,7 +148,7 @@ class MDParser(ArchiveWriter):
         data: dict[str, Any],
         simulation: Simulation,
         model_system: ModelSystem = None,
-        representation: Representation = None,
+        representation: AlternativeRepresentation = None,
     ) -> None:
         """
         Create a system section and write the provided data.
@@ -158,15 +161,17 @@ class MDParser(ArchiveWriter):
         if model_system is None:
             model_system = ModelSystem()
         if representation is None:
-            representation = Representation()
+            representation = AlternativeRepresentation()
 
-        cell_dict = data.pop('cell')
+        repr_dict = data.pop('representation')
         particle_labels = data.pop('labels')
+        dimensions = data.pop('dimensions')
         for label in particle_labels:
             particle_state = ParticleState(label=label)
             model_system.particle_states.append(particle_state)
-        self.parse_section(cell_dict, representation)
+        self.parse_section(repr_dict, representation)
         model_system.representations.append(representation)
+        model_system.dimensionality = dimensions
         self.parse_section(data, model_system)
         simulation.model_system.append(model_system)
 
@@ -225,7 +230,7 @@ class MDParser(ArchiveWriter):
         if self.archive is None:
             return
 
-        sec_workflow = MolecularDynamics()
+        sec_workflow = workflow.MolecularDynamics()
         self.parse_section(data, sec_workflow)
         self.archive.workflow2 = sec_workflow
 

--- a/src/nomad_simulation_parsers/parsers/utils/mdparserutils.py
+++ b/src/nomad_simulation_parsers/parsers/utils/mdparserutils.py
@@ -163,15 +163,23 @@ class MDParser(ArchiveWriter):
         if representation is None:
             representation = AlternativeRepresentation()
 
-        repr_dict = data.pop('representation')
+        lattice_vectors = data.pop('lattice_vectors')
+        periodic_boundary_conditions = data.pop('periodic_boundary_conditions')
         particle_labels = data.pop('labels')
         dimensions = data.pop('dimensions')
+
         for label in particle_labels:
             particle_state = ParticleState(label=label)
             model_system.particle_states.append(particle_state)
-        self.parse_section(repr_dict, representation)
-        model_system.representations.append(representation)
+
+        q_lattice = model_system.m_get_quantity_definition('lattice_vectors')
+        model_system.m_set(q_lattice, lattice_vectors)
+
+        q_pbc = model_system.m_get_quantity_definition('periodic_boundary_conditions')
+        model_system.m_set(q_pbc, periodic_boundary_conditions)
+
         model_system.dimensionality = dimensions
+
         self.parse_section(data, model_system)
         simulation.model_system.append(model_system)
 


### PR DESCRIPTION
In `mdparserutils.MDParser`, using `Representation` directly raises:
```
nomad-distro-dev/packages/nomad-FAIR/nomad/metainfo/metainfo.py:1353: SyntaxWarning: Representation(lattice_vectors, periodic_boundary_conditions) is not derived from its definition nomad_simulations.schema_packages.model_system.ModelSystem.representations:SubSection.
```
- Updated import to use AlternativeRepresentation from model_system
- Changed parse_trajectory_step parameter type
- Changed instantiation in parse_trajectory_step
- Resolves SyntaxWarning about schema validation