### PR TITLE
remove annotations fixes

### DIFF
--- a/src/nomad_simulation_parsers/parsers/exciting/parser.py
+++ b/src/nomad_simulation_parsers/parsers/exciting/parser.py
@@ -249,7 +249,16 @@ class ExcitingArchiveWriter(ArchiveWriter):
         data_parser.close()
 
         # remove annotations
-        remove_mapping_annotations(exciting.general.Simulation.m_def)
+        remove_mapping_annotations(
+            exciting.general.Simulation.m_def,
+            annotation_keys=[
+                exciting.INFO_KEY,
+                exciting.INPUT_XML_KEY,
+                exciting.EIGVAL_KEY,
+                exciting.BANDSTRUCTURE_XML_KEY,
+                exciting.DOS_XML_KEY,
+            ],
+        )
 
 
 class ExcitingParser(MatchingParser):

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -551,7 +551,17 @@ class FHIAimsArchiveWriter(ArchiveWriter):
         # archive_handler.close()
 
         # remove annotations
-        remove_mapping_annotations(fhiaims.general.Simulation.m_def)
+        remove_mapping_annotations(
+            fhiaims.general.Simulation.m_def,
+            annotation_keys=[
+                fhiaims.TEXT_KEY,
+                fhiaims.TEXT_DOS_KEY,
+                fhiaims.TEXT_GW_KEY,
+                fhiaims.SINGLE_POINT_KEY,
+                fhiaims.GEO_OPT_WORKFLOW_KEY,
+                fhiaims.MD_WORKFLOW_KEY,
+            ],
+        )
 
 
 class FHIAimsParser(MatchingParser):

--- a/src/nomad_simulation_parsers/parsers/h5md/parser.py
+++ b/src/nomad_simulation_parsers/parsers/h5md/parser.py
@@ -529,7 +529,10 @@ class H5MDArchiveWriter(MDParser):
         self.workflow_parser.close()
 
         # remove mapping annotations
-        remove_mapping_annotations(self.archive.data.m_def)
+        remove_mapping_annotations(
+            self.archive.data.m_def,
+            annotation_keys=[h5md.HDF5_KEY],
+        )
 
 
 class H5MDParser(MatchingParser):

--- a/src/nomad_simulation_parsers/schema_packages/utils.py
+++ b/src/nomad_simulation_parsers/schema_packages/utils.py
@@ -1,45 +1,71 @@
-from typing import Any
+from typing import Any, Iterable
 
 from nomad.datamodel.metainfo.annotations import Mapper
 from nomad.metainfo import Quantity, Section, SubSection
 from nomad.parsing.file_parser.mapping_parser import MAPPING_ANNOTATION_KEY
 
 
-def remove_mapping_annotations(property: Section, max_depth: int = 5) -> None:
+def remove_mapping_annotations(
+    property: Section | SubSection,
+    max_depth: int = 5,
+    annotation_keys: Iterable[str] | None = None,
+) -> None:
     """
     Remove mapping annotations from the input section definition, all its quantities
     and sub-sections recursively.
+
     Args:
-        property (Section): The section definition to remove the annotations from.
-        max_depth (int, optional): The maximum depth of the recursion for sub-sections
-            using the same section as parent.
+        property: The section definition or subsection to remove annotations from.
+        max_depth: The maximum depth of the recursion for sub-sections using the same
+            section as parent.
+        annotation_keys: Optional set of annotation keys that should be removed.
+            When omitted, all mapping annotations are removed (legacy behaviour).
     """
 
-    def _remove(property: Section | SubSection, depth: int = 0):
+    annotation_keys = set(annotation_keys) if annotation_keys is not None else None
+    visited_sections: set[int] = set()
+
+    def _clear_annotations(target: Section | SubSection | Quantity) -> None:
+        mapping = target.m_annotations.get(MAPPING_ANNOTATION_KEY)
+        if not mapping:
+            return
+        if annotation_keys is None:
+            target.m_annotations.pop(MAPPING_ANNOTATION_KEY, None)
+            return
+        for key in annotation_keys:
+            mapping.pop(key, None)
+        if not mapping:
+            target.m_annotations.pop(MAPPING_ANNOTATION_KEY, None)
+
+    def _remove(property: Section | SubSection, depth: int = 0) -> None:
         if depth > max_depth:
             return
 
-        annotation_key = 'mapping'
-        property.m_annotations.pop(annotation_key, None)
+        _clear_annotations(property)
 
-        depth += 1
         property_section = (
             property.sub_section if isinstance(property, SubSection) else property
         )
+        if property_section is None:
+            return
+
+        _clear_annotations(property_section)
+
+        section_id = id(property_section)
+        if section_id in visited_sections:
+            return
+        visited_sections.add(section_id)
+
+        next_depth = depth + 1
+
         for quantity in property_section.all_quantities.values():
-            quantity.m_annotations.pop(annotation_key, None)
+            _clear_annotations(quantity)
 
         for sub_section in property_section.all_sub_sections.values():
-            if sub_section.m_annotations.get(annotation_key):
-                _remove(sub_section, depth)
-            elif sub_section.sub_section.m_annotations.get(annotation_key):
-                _remove(sub_section.sub_section, depth)
-            else:
-                for (
-                    inheriting_section
-                ) in sub_section.sub_section.all_inheriting_sections:
-                    if inheriting_section.m_annotations.get(annotation_key):
-                        _remove(inheriting_section, depth)
+            _remove(sub_section, next_depth)
+
+        for inheriting_section in property_section.all_inheriting_sections:
+            _remove(inheriting_section, next_depth)
 
     _remove(property)
 

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -31,6 +31,8 @@ class Simulation(general.Simulation):
     add_mapping_annotation(general.Simulation.program, XML_KEY, '.generator')
     add_mapping_annotation(general.Simulation.program, OUTCAR_KEY, '.header')
     # dft method
+    add_mapping_annotation(general.Simulation.model_method, XML_KEY, '.parameters')
+    add_mapping_annotation(general.Simulation.model_method, OUTCAR_KEY, '.parameters')
     add_mapping_annotation(
         model_method.DFT.m_def,
         XML_KEY,


### PR DESCRIPTION
# VASP OUTCAR Parser Fix

## Symptoms
- `tests/parsers/test_vasp_parser.py::test_outcar` passed when executed alone but failed (`AssertionError: No model_method in simulation`) once the full parser suite ran.

## Root Cause
1. The VASP schema lacked mapping entries for the parent `general.Simulation.model_method` subsection, so the OUTCAR mapping could not materialize the parent before filling `model_method.DFT`.
2. Other parser tests (`exciting`, `FHI-aims`, `H5MD`) called `remove_mapping_annotations` with no filter, which wiped *all* mapping keys from the shared `general.Simulation` definition after their runs, erasing the VASP mappings even after they were added.

## Fix
- Added the missing parent annotations in `src/nomad_simulation_parsers/schema_packages/vasp.py`:
  ```python
  add_mapping_annotation(general.Simulation.model_method, XML_KEY, '.parameters')
  add_mapping_annotation(general.Simulation.model_method, OUTCAR_KEY, '.parameters')
  ```
- Extended `remove_mapping_annotations` to accept an `annotation_keys` filter and updated the `exciting`, `FHI-aims`, and `H5MD` parsers to drop only their own mapping keys. This keeps their cleanup behavior without stripping VASP’s `xml`/`outcar` mappings.

## Verification
```
$ uv run --directory packages/nomad-parser-plugins-simulation pytest \
    tests/parsers/test_vasp_parser.py tests/parsers/test_quantumespresso_parser.py
$ uv run --directory packages/nomad-parser-plugins-simulation pytest tests
```
Both commands now pass; `test_outcar` succeeds regardless of suite order.

## Notes
- QE failures (`IndexError: pop index out of range` inside `Simulation.model_system` removal) were ultimately due to the shared mapper cache leaking data between parsers. The [FIX](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/2823) lives in `nomad-FAIR`; without it you would have to run QE tests in isolation because there’s no robust way to prevent the cache from reusing ABINIT’s data mid-suite.
