### PR TITLE
Update nomad-simulations urls after org migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ maintainers = [
 license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab>=1.3.16.dev100",
-    "nomad-simulations@git+https://github.com/nomad-coe/nomad-simulations.git@develop",
+    "nomad-simulations@git+https://github.com/fairmat-nfdi/nomad-simulations.git@develop",
     "nomad-schema-plugin-simulation-workflow>=1.0.10",
     "python-magic-bin; sys_platform == 'win32'",
     "phonopy>=2.35",
@@ -47,7 +47,7 @@ Repository = "https://github.com/FAIRmat-NFDI/nomad-simulation-parsers"
 
 [project.optional-dependencies]
 md = [
-    "nomad-simulations[md]@git+https://github.com/nomad-coe/nomad-simulations.git@develop",
+    "nomad-simulations[md]@git+https://github.com/fairmat-nfdi/nomad-simulations.git@develop",
     "MDAnalysis>=2.4.0",
 ]
 dev = ["ruff", "pytest", "structlog"]


### PR DESCRIPTION
nomad-simulations has been migrated from nomad-coe to fairmat-nfdi org. There is an automatic redirect that should allow smooth transition with the old setup. But I update the urls here for clarity.