### PR TITLE
Fix global mapping annotation contamination in parsers

### DIFF
--- a/src/nomad_simulation_parsers/parsers/__init__.py
+++ b/src/nomad_simulation_parsers/parsers/__init__.py
@@ -191,7 +191,7 @@ vasp_parser = EntryPoint(
     mainfile_contents_re=(
         r'^\s*<\?xml version="1\.0" encoding="ISO-8859-1"\?>\s*?\s*<modeling>?\s*'
         r'<generator>?\s*<i name="program" type="string">\s*vasp\s*</i>?|'
-        r'^\svasp[\.\d]+.+?(?:\(build|complex)[\s\S]+?executed on'
+        r'^\s*vasp[\.\d]+.+?(?:\(build|complex)[\s\S]+?executed on'
     ),
     mainfile_mime_re='(application/.*)|(text/.*)',
     mainfile_name_re='.*[^/]*xml[^/]*',

--- a/src/nomad_simulation_parsers/parsers/__init__.py
+++ b/src/nomad_simulation_parsers/parsers/__init__.py
@@ -25,6 +25,7 @@ class EntryPoint(ParserEntryPoint):
             LOGGER.error(
                 f'Could not load parser class {self.parser_class_name}', exc_info=e
             )
+            raise
 
 
 class Wannier90ParserEntryPoint(EntryPoint):

--- a/src/nomad_simulation_parsers/parsers/__init__.py
+++ b/src/nomad_simulation_parsers/parsers/__init__.py
@@ -194,7 +194,7 @@ vasp_parser = EntryPoint(
         r'^\s*vasp[\.\d]+.+?(?:\(build|complex)[\s\S]+?executed on'
     ),
     mainfile_mime_re='(application/.*)|(text/.*)',
-    mainfile_name_re='.*[^/]*xml[^/]*',
+    mainfile_name_re=r'.*[^/]*(xml|OUTCAR)[^/]*',
     mainfile_alternative=True,
     supported_compressions=['gz', 'bz2', 'xz'],
 )

--- a/src/nomad_simulation_parsers/parsers/abinit/parser.py
+++ b/src/nomad_simulation_parsers/parsers/abinit/parser.py
@@ -1,7 +1,6 @@
 import os
 from collections.abc import Iterable
 from datetime import datetime
-from importlib import reload
 from typing import Any
 
 import numpy as np
@@ -623,8 +622,6 @@ class AbinitArchiveWriter(ArchiveWriter):
         self.mainfile_parser.convert(self.metainfo_parser)
 
     def write_to_archive(self):
-        reload(abinit)
-
         self.archive.data = Simulation(program=Program(name=self.code_name))
         self.metainfo_parser.annotation_key = self.annotation_key
         self.metainfo_parser.data_object = self.archive.data

--- a/src/nomad_simulation_parsers/parsers/ams/parser.py
+++ b/src/nomad_simulation_parsers/parsers/ams/parser.py
@@ -1,5 +1,4 @@
 import os
-from importlib import reload
 from typing import Any
 
 import numpy as np
@@ -78,9 +77,6 @@ class AMSArchiveWriter(ArchiveWriter):
     rkf_parser = RKFParser(text_parser=RKFTextParser())
 
     def write_to_archive(self):
-        # reload schema package to use correct annotations
-        reload(ams)
-
         self.metainfo_parser.annotation_key = ams.OUT_KEY
         self.archive.data = Simulation(program=Program(name='AMS'))
         self.metainfo_parser.data_object = self.archive.data

--- a/src/nomad_simulation_parsers/parsers/crystal/parser.py
+++ b/src/nomad_simulation_parsers/parsers/crystal/parser.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import re
-from importlib import reload
 from typing import Any
 
 import numpy as np
@@ -207,9 +206,6 @@ class CrystalArchiveWriter(ArchiveWriter):
     archive_parser = CrystalMetainfoParser()
 
     def write_to_archive(self):
-        # reload schema to update annotations
-        reload(crystal)
-
         # main output file
         self.archive_parser.annotation_key = crystal.OUT_KEY
         self.archive_parser.data_object = Simulation(program=Program(name='Crystal'))

--- a/src/nomad_simulation_parsers/parsers/exciting/parser.py
+++ b/src/nomad_simulation_parsers/parsers/exciting/parser.py
@@ -1,5 +1,4 @@
 import os
-from importlib import reload
 from typing import Any
 
 import numpy as np
@@ -24,7 +23,6 @@ from nomad_simulation_parsers.parsers.utils.general import (
     search_files,
 )
 from nomad_simulation_parsers.schema_packages import exciting
-from nomad_simulation_parsers.schema_packages.utils import remove_mapping_annotations
 
 from .eigval_parser import EigvalFileParser
 from .info_parser import InfoFileParser
@@ -185,8 +183,6 @@ class EigvalParser(TextParser):
 
 class ExcitingArchiveWriter(ArchiveWriter):
     def write_to_archive(self) -> None:
-        reload(exciting)
-
         maindir = os.path.dirname(self.mainfile)
         mainbase = os.path.basename(self.mainfile)
 
@@ -247,9 +243,6 @@ class ExcitingArchiveWriter(ArchiveWriter):
         # close parsers
         info_parser.close()
         data_parser.close()
-
-        # remove annotations
-        remove_mapping_annotations(exciting.general.Simulation.m_def)
 
 
 class ExcitingParser(MatchingParser):

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -1,7 +1,6 @@
 import os
 import re
 from collections.abc import Iterable
-from importlib import reload
 from typing import Any
 
 import numpy as np
@@ -41,7 +40,6 @@ from nomad_simulation_parsers.parsers.utils.general import (
     search_files,
 )
 from nomad_simulation_parsers.schema_packages import fhiaims
-from nomad_simulation_parsers.schema_packages.utils import remove_mapping_annotations
 
 from .common import ControlParser, GeometryParser
 
@@ -446,9 +444,6 @@ class FHIAimsArchiveWriter(ArchiveWriter):
     def write_to_archive(
         self,
     ) -> None:
-        # reload module to refresh annotations
-        reload(fhiaims)
-
         out_parser = FHIAimsOutMappingParser()
         out_parser.text_parser = FHIAimsOutFileParser()
         out_parser.filepath = self.mainfile
@@ -549,9 +544,6 @@ class FHIAimsArchiveWriter(ArchiveWriter):
         self.archive_handler = archive_handler
         # out_parser.close()
         # archive_handler.close()
-
-        # remove annotations
-        remove_mapping_annotations(fhiaims.general.Simulation.m_def)
 
 
 class FHIAimsParser(MatchingParser):

--- a/src/nomad_simulation_parsers/parsers/gpaw/parser.py
+++ b/src/nomad_simulation_parsers/parsers/gpaw/parser.py
@@ -1,4 +1,3 @@
-from importlib import reload
 from typing import Any
 
 from nomad.datamodel import EntryArchive
@@ -90,9 +89,6 @@ class GPAWArchiveWriter(ArchiveWriter):
     archive_parser = GPAWMetainfoParser()
 
     def write_to_archive(self):
-        # reload schema annotations
-        reload(gpaw)
-
         self.mainfile_parser.filepath = self.mainfile
         self.archive_parser.annotation_key = gpaw.GPW_KEY
         self.archive_parser.data_object = Simulation()

--- a/src/nomad_simulation_parsers/parsers/h5md/parser.py
+++ b/src/nomad_simulation_parsers/parsers/h5md/parser.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from importlib import reload
 from typing import Any
 
 import numpy as np
@@ -16,7 +15,6 @@ from structlog.stdlib import BoundLogger
 from nomad_simulation_parsers.parsers.utils.mdparserutils import MDParser
 from nomad_simulation_parsers.schema_packages import h5md
 from nomad_simulation_parsers.schema_packages.h5md import MolecularDynamics, Simulation
-from nomad_simulation_parsers.schema_packages.utils import remove_mapping_annotations
 
 LOGGER = get_logger(__name__)
 
@@ -492,9 +490,6 @@ class H5MDArchiveWriter(MDParser):
         super().__init__(**kwargs)
 
     def write_to_archive(self) -> None:
-        # reload schema annotations
-        reload(h5md)
-
         # create h5 parser
         self.h5_parser.filepath = self.mainfile
 
@@ -527,9 +522,6 @@ class H5MDArchiveWriter(MDParser):
         self.h5_parser.close()
         self.simulation_parser.close()
         self.workflow_parser.close()
-
-        # remove mapping annotations
-        remove_mapping_annotations(self.archive.data.m_def)
 
 
 class H5MDParser(MatchingParser):

--- a/src/nomad_simulation_parsers/parsers/octopus/parser.py
+++ b/src/nomad_simulation_parsers/parsers/octopus/parser.py
@@ -1,5 +1,4 @@
 import os
-from importlib import reload
 from typing import Any
 
 import numpy as np
@@ -417,9 +416,6 @@ class OctopusArchiveWriter(ArchiveWriter):
     eigenvalues_parser = OctopusEigenvalueParser(text_parser=EigenvalueParser())
 
     def write_to_archive(self) -> None:
-        # Reload the octopus package to update the mapping annotations
-        reload(octopus)
-
         self.mainfile_parser.filepath = self.mainfile
         # initialize auxiliary file parsers
         self.mainfile_parser.init_parser()

--- a/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
+++ b/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
@@ -2,7 +2,6 @@ import os
 import re
 from collections.abc import Iterable
 from datetime import datetime
-from importlib import reload
 from types import ModuleType
 from typing import Any
 
@@ -218,8 +217,6 @@ class QuantumEspressoArchiveWriter(ArchiveWriter):
     mainfile_parser = MainfileParser(text_parser=QuantumEspressoFileParser())
 
     def parse_program(self, archive: EntryArchive, index: int) -> None:
-        # reload the schema annotations
-        reload(self.schema)
         self.simulation_parser.data_object = Simulation(
             program=Program(name='Quantum Espresso')
         )

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -492,6 +492,16 @@ class OutcarParser(MappingTextParser):
             )
         return data
 
+    def get_pseudopotentials(self, pseudopotentials: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """
+        Filter and return non-empty pseudopotential dictionaries.
+
+        The OUTCAR parser extracts 4 POTCAR entries but the first 2 are just
+        short header lines without full data. This transformer filters out
+        empty dicts to return only valid pseudopotential data.
+        """
+        return [pp for pp in pseudopotentials if pp]
+
     def get_xc_functionals(self, parameters: dict[str, Any]) -> list[dict[str, Any]]:
         xc_functionals = []
         if parameters.get('LHFCALC', False):
@@ -539,47 +549,41 @@ class OutcarArchiveWriter(ArchiveWriter):
     def _process_pseudopotentials(
         self,
         archive_data: Simulation,
-        pseudopotentials_data: list[dict[str, Any]],
-        text_parser: Any,
     ) -> None:
-        """Process POTCAR information and create Pseudopotential instances."""
-        if not pseudopotentials_data:
-            return
+        """
+        Post-process Pseudopotential instances created by mapping annotations.
 
-        # Filter out empty dicts (from short POTCAR header lines)
-        pseudopotentials_data = [pp for pp in pseudopotentials_data if pp]
-
+        This method handles complex transformations that cannot be expressed
+        in declarative mapping annotations:
+        - Type determination (PAW, NC-PAW, US, NC) from LPAW/LULTRA flags
+        - is_norm_conserving flag based on type
+        - GW optimization detection
+        - XC functional subsection creation and normalization
+        - Linking pseudopotentials to AtomsState
+        """
         # Ensure model_method exists
-        if not archive_data.model_method:
-            from nomad_simulations.schema_packages.model_method import ModelMethod
-
-            archive_data.model_method = [ModelMethod()]
+        if not archive_data.model_method or len(archive_data.model_method) == 0:
+            return
 
         model_method = archive_data.model_method[0]
 
-        for pp_data in pseudopotentials_data:
-            pp = vasp.Pseudopotential()
+        # Check if any pseudopotentials were created by mapping annotations
+        if not model_method.numerical_settings:
+            return
 
-            # Basic metadata (mapping annotations defined in vasp.py)
-            pp.name = pp_data.get('titel', '')
-            if 'zval' in pp_data:
-                pp.n_valence_electrons = pp_data['zval']
-            if 'vrhfin' in pp_data:
-                pp.reference_configuration = pp_data['vrhfin']
-            if 'rcore' in pp_data:
-                pp.r_core = pp_data['rcore'] * ureg.angstrom
+        for pp in model_method.numerical_settings:
+            # Skip non-pseudopotential numerical settings (if any exist)
+            if not isinstance(pp, vasp.Pseudopotential):
+                continue
 
-            # VASP-specific cutoffs
-            if 'enmax' in pp_data:
-                pp.enmax = pp_data['enmax'] * ureg.eV
-                pp.cutoff = pp_data['enmax'] * ureg.eV
+            # Get the corresponding pp_data to access raw parsed values
+            # The mapping annotations have already populated basic fields (name, n_valence_electrons,
+            # reference_configuration, r_core, cutoff, enmax, enmin, sha256)
+            pp_data = pp.m_cache.get(vasp.OUTCAR_KEY, {})
+
+            # Set cutoff_target (derived field not directly in source data)
+            if pp.enmax:
                 pp.cutoff_target = 'ENMAX'
-            if 'enmin' in pp_data:
-                pp.enmin = pp_data['enmin'] * ureg.eV
-
-            # SHA256 hash
-            if 'sha256' in pp_data:
-                pp.sha256 = pp_data['sha256']
 
             # Determine type from POTCAR flags and name
             # TODO: Double-check VASP's norm-conserving annotation logic:
@@ -643,21 +647,19 @@ class OutcarArchiveWriter(ArchiveWriter):
                 xc.functional_key = functional_name
                 pp.xc_functional = xc
 
-            # Add to numerical_settings
-            if not model_method.numerical_settings:
-                model_method.numerical_settings = []
-            model_method.numerical_settings.append(pp)
-
         # Link pseudopotentials to AtomsState
         # VASP lists pseudopotentials in POSCAR species order
         if archive_data.model_system and len(archive_data.model_system) > 0:
             model_system = archive_data.model_system[0]
             if hasattr(model_system, 'particle_states') and model_system.particle_states:
-                # Get the pseudopotentials we just created
-                created_pseudopotentials = model_method.numerical_settings[-len(pseudopotentials_data):]
+                # Get only the Pseudopotential objects
+                pseudopotentials = [
+                    ns for ns in model_method.numerical_settings
+                    if isinstance(ns, vasp.Pseudopotential)
+                ]
 
                 # Link each AtomsState to its corresponding Pseudopotential
-                for atoms_state, pp in zip(model_system.particle_states, created_pseudopotentials):
+                for atoms_state, pp in zip(model_system.particle_states, pseudopotentials):
                     atoms_state.pseudopotential = pp
 
     def write_to_archive(self) -> None:
@@ -672,19 +674,12 @@ class OutcarArchiveWriter(ArchiveWriter):
         source_parser.text_parser = OutcarTextParser()
         source_parser.filepath = self.mainfile
 
-        # TODO remove this for debug only
-        self.archive_data_parser = archive_data_parser
-        self.source_parser = source_parser
-
         # convert
         source_parser.convert(archive_data_parser)
 
-        # Process pseudopotentials
-        pseudopotentials_data = source_parser.text_parser.get('pseudopotentials', [])
-        if pseudopotentials_data:
-            self._process_pseudopotentials(
-                archive_data, pseudopotentials_data, source_parser.text_parser
-            )
+        # Post-process pseudopotentials created by mapping annotations
+        # This handles complex transformations (type, XC functional, linking)
+        self._process_pseudopotentials(archive_data)
 
         # assign simulation section to archive data
         self.archive.data = archive_data_parser.data_object

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -576,17 +576,12 @@ class OutcarArchiveWriter(ArchiveWriter):
             if not isinstance(pp, vasp.Pseudopotential):
                 continue
 
-            # Get the corresponding pp_data to access raw parsed values
-            # The mapping annotations have already populated basic fields (name, n_valence_electrons,
-            # reference_configuration, r_core, cutoff, enmax, enmin, sha256)
-            pp_data = pp.m_cache.get(vasp.OUTCAR_KEY, {})
-
+            # Mapping annotations have populated all fields including lpaw, lultra, lexch
             # Set cutoff_target (derived field not directly in source data)
             if pp.enmax:
                 pp.cutoff_target = 'ENMAX'
 
             # Determine type from POTCAR flags and name
-            # TODO: Double-check VASP's norm-conserving annotation logic:
             # VASP uses LPAW and LULTRA flags in POTCAR (parsed from OUTCAR):
             #   - LPAW=T: PAW potential
             #     - Title contains '_GW' → NC-PAW-GW (norm-conserving)
@@ -596,9 +591,9 @@ class OutcarArchiveWriter(ArchiveWriter):
             #   - Both LPAW=F and LULTRA=F: Fully norm-conserving (NC)
             # VASP does NOT have an explicit "LNORMCONS" flag - absence of both
             # LPAW and LULTRA indicates standard norm-conserving pseudopotential.
-            lpaw = pp_data.get('lpaw', False)
-            lultra = pp_data.get('lultra', False)
-            is_gw = '_GW' in pp_data.get('titel', '')
+            lpaw = pp.lpaw if hasattr(pp, 'lpaw') and pp.lpaw is not None else False
+            lultra = pp.lultra if hasattr(pp, 'lultra') and pp.lultra is not None else False
+            is_gw = '_GW' in pp.name if pp.name else False
 
             if lpaw:
                 # PAW potential
@@ -607,8 +602,8 @@ class OutcarArchiveWriter(ArchiveWriter):
                     pp.is_norm_conserving = True  # GW potentials have NC partial waves
                 else:
                     # Check for NC-PAW variant (rare without GW, but possible)
-                    titel = pp_data.get('titel', '').lower()
-                    if 'nc' in titel and 'paw' in titel:
+                    titel_lower = pp.name.lower() if pp.name else ''
+                    if 'nc' in titel_lower and 'paw' in titel_lower:
                         pp.type = 'NC-PAW'
                         pp.is_norm_conserving = True
                     else:
@@ -623,14 +618,14 @@ class OutcarArchiveWriter(ArchiveWriter):
                 pp.type = 'NC'
                 pp.is_norm_conserving = True
 
-            # GW optimization detection (keep for backward compatibility)
-            if '_GW' in pp_data.get('titel', ''):
+            # GW optimization detection
+            if is_gw:
                 pp.gw_optimized = True
 
             # XC functional
-            if 'lexch' in pp_data:
+            if hasattr(pp, 'lexch') and pp.lexch:
                 xc = XCFunctional()
-                lexch_code = pp_data['lexch']
+                lexch_code = pp.lexch
 
                 # Map VASP LEXCH codes to standard functional names
                 vasp_xc_map = {

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -622,8 +622,20 @@ class OutcarArchiveWriter(ArchiveWriter):
             if 'lexch' in pp_data:
                 xc = XCFunctional()
                 lexch_code = pp_data['lexch']
-                # Store the VASP LEXCH code directly; normalization will expand to LibXC names
-                xc.functional_key = lexch_code
+
+                # Map VASP LEXCH codes to standard functional names
+                vasp_xc_map = {
+                    'PE': 'PBE',
+                    'PS': 'PBEsol',
+                    'CA': 'LDA',
+                    '91': 'PW91',
+                    'AM': 'AM05',
+                    'RP': 'RPBE',
+                    'PW': 'PW91',
+                }
+
+                functional_name = vasp_xc_map.get(lexch_code, lexch_code)
+                xc.functional_key = functional_name
                 pp.xc_functional = xc
 
             # Add to numerical_settings

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -185,6 +185,16 @@ class OutcarTextParser(TextParser):
             if sha256_match:
                 data['sha256'] = sha256_match.group(1)
 
+            # Extract LMAX (number of l-projection operators)
+            lmax_match = re.search(r'number of l-projection\s+operators is LMAX\s*=\s*(\d+)', val_in)
+            if lmax_match:
+                data['lmax'] = int(lmax_match.group(1))
+
+            # Extract LMMAX (number of lm-projection operators)
+            lmmax_match = re.search(r'number of lm-projection operators is LMMAX\s*=\s*(\d+)', val_in)
+            if lmmax_match:
+                data['lmmax'] = int(lmmax_match.group(1))
+
             return data
 
         scf_iteration = [

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -588,24 +588,24 @@ class OutcarArchiveWriter(ArchiveWriter):
                 # PAW potential
                 if is_gw:
                     pp.type = 'NC-PAW-GW'
-                    pp.norm_conserving = True  # GW potentials have NC partial waves
+                    pp.is_norm_conserving = True  # GW potentials have NC partial waves
                 else:
                     # Check for NC-PAW variant (rare without GW, but possible)
                     titel = pp_data.get('titel', '').lower()
                     if 'nc' in titel and 'paw' in titel:
                         pp.type = 'NC-PAW'
-                        pp.norm_conserving = True
+                        pp.is_norm_conserving = True
                     else:
                         pp.type = 'PAW'
-                        pp.norm_conserving = False
+                        pp.is_norm_conserving = False
             elif lultra:
                 # Ultrasoft (always Vanderbilt formalism)
                 pp.type = 'US'
-                pp.norm_conserving = False
+                pp.is_norm_conserving = False
             else:
                 # Fully norm-conserving (non-PAW, non-ultrasoft)
                 pp.type = 'NC'
-                pp.norm_conserving = True
+                pp.is_norm_conserving = True
 
             # GW optimization detection (keep for backward compatibility)
             if '_GW' in pp_data.get('titel', ''):

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -180,6 +180,11 @@ class OutcarTextParser(TextParser):
             if lultra_match:
                 data['lultra'] = lultra_match.group(1) == 'T'
 
+            # Extract SHA256 hash
+            sha256_match = re.search(r'SHA256\s*=\s*([a-f0-9]{64})', val_in)
+            if sha256_match:
+                data['sha256'] = sha256_match.group(1)
+
             return data
 
         scf_iteration = [
@@ -585,8 +590,23 @@ class OutcarArchiveWriter(ArchiveWriter):
             # Store representative cutoff (convert eV to joules)
             if 'enmax' in pp_data:
                 pp.cutoff = pp_data['enmax'] * EV_TO_JOULE
+                pp.cutoff_target = 'ENMAX'
+
+            # SHA256 hash for unique identification
+            if 'sha256' in pp_data:
+                pp.sha256 = pp_data['sha256']
 
             # Determine type from POTCAR flags and name
+            # TODO: Double-check VASP's norm-conserving annotation logic:
+            # VASP uses LPAW and LULTRA flags in POTCAR (parsed from OUTCAR):
+            #   - LPAW=T: PAW potential
+            #     - Title contains '_GW' → NC-PAW-GW (norm-conserving)
+            #     - Title contains 'nc' and 'paw' → NC-PAW (norm-conserving)
+            #     - Otherwise → PAW (NOT norm-conserving)
+            #   - LULTRA=T: Ultrasoft (US, NOT norm-conserving)
+            #   - Both LPAW=F and LULTRA=F: Fully norm-conserving (NC)
+            # VASP does NOT have an explicit "LNORMCONS" flag - absence of both
+            # LPAW and LULTRA indicates standard norm-conserving pseudopotential.
             lpaw = pp_data.get('lpaw', False)
             lultra = pp_data.get('lultra', False)
             is_gw = '_GW' in pp_data.get('titel', '')

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -560,14 +560,26 @@ class OutcarArchiveWriter(ArchiveWriter):
         for pp_data in pseudopotentials_data:
             pp = vasp.Pseudopotential()
 
-            # Use mapping annotation keys (defined in vasp.py with OUTCAR_KEY)
-            # The annotations specify unit conversion, so we pass raw values
-            pp.m_cache = {'OUTCAR_KEY': pp_data}
+            # Basic metadata (mapping annotations defined in vasp.py)
+            pp.name = pp_data.get('titel', '')
+            if 'zval' in pp_data:
+                pp.n_valence_electrons = pp_data['zval']
+            if 'vrhfin' in pp_data:
+                pp.reference_configuration = pp_data['vrhfin']
+            if 'rcore' in pp_data:
+                pp.r_core = pp_data['rcore'] * ureg.angstrom
 
-            # Fields not covered by mapping annotations:
+            # VASP-specific cutoffs
             if 'enmax' in pp_data:
+                pp.enmax = pp_data['enmax'] * ureg.eV
                 pp.cutoff = pp_data['enmax'] * ureg.eV
                 pp.cutoff_target = 'ENMAX'
+            if 'enmin' in pp_data:
+                pp.enmin = pp_data['enmin'] * ureg.eV
+
+            # SHA256 hash
+            if 'sha256' in pp_data:
+                pp.sha256 = pp_data['sha256']
 
             # Determine type from POTCAR flags and name
             # TODO: Double-check VASP's norm-conserving annotation logic:

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -549,6 +549,7 @@ class OutcarArchiveWriter(ArchiveWriter):
     def _process_pseudopotentials(
         self,
         archive_data: Simulation,
+        parser_data: dict[str, Any],
     ) -> None:
         """
         Post-process Pseudopotential instances created by mapping annotations.
@@ -560,6 +561,10 @@ class OutcarArchiveWriter(ArchiveWriter):
         - GW optimization detection
         - XC functional subsection creation and normalization
         - Linking pseudopotentials to AtomsState
+
+        Args:
+            archive_data: The simulation archive being populated
+            parser_data: Raw parsed data containing lpaw, lultra, lexch flags
         """
         # Ensure model_method exists
         if not archive_data.model_method or len(archive_data.model_method) == 0:
@@ -571,15 +576,28 @@ class OutcarArchiveWriter(ArchiveWriter):
         if not model_method.numerical_settings:
             return
 
+        # Get pseudopotential data from parser (filter out empty dicts)
+        # The OUTCAR parser extracts 4 POTCAR entries but the first 2 are just
+        # short header lines without full data
+        raw_pseudopotentials = [pp for pp in parser_data.get('pseudopotentials', []) if pp]
+
+        pp_index = 0  # Track actual pseudopotential index (skipping non-PP numerical_settings)
         for pp in model_method.numerical_settings:
             # Skip non-pseudopotential numerical settings (if any exist)
             if not isinstance(pp, vasp.Pseudopotential):
                 continue
 
-            # Mapping annotations have populated all fields including lpaw, lultra, lexch
             # Set cutoff_target (derived field not directly in source data)
             if pp.enmax:
                 pp.cutoff_target = 'ENMAX'
+
+            # Get lpaw, lultra, lexch from raw parser data (not stored in schema)
+            # These flags are used only to derive type and is_norm_conserving
+            raw_pp = raw_pseudopotentials[pp_index] if pp_index < len(raw_pseudopotentials) else {}
+            lpaw = raw_pp.get('lpaw', False)
+            lultra = raw_pp.get('lultra', False)
+            lexch = raw_pp.get('lexch')
+            pp_index += 1
 
             # Determine type from POTCAR flags and name
             # VASP uses LPAW and LULTRA flags in POTCAR (parsed from OUTCAR):
@@ -591,8 +609,6 @@ class OutcarArchiveWriter(ArchiveWriter):
             #   - Both LPAW=F and LULTRA=F: Fully norm-conserving (NC)
             # VASP does NOT have an explicit "LNORMCONS" flag - absence of both
             # LPAW and LULTRA indicates standard norm-conserving pseudopotential.
-            lpaw = pp.lpaw if hasattr(pp, 'lpaw') and pp.lpaw is not None else False
-            lultra = pp.lultra if hasattr(pp, 'lultra') and pp.lultra is not None else False
             is_gw = '_GW' in pp.name if pp.name else False
 
             if lpaw:
@@ -622,10 +638,10 @@ class OutcarArchiveWriter(ArchiveWriter):
             if is_gw:
                 pp.gw_optimized = True
 
-            # XC functional
-            if hasattr(pp, 'lexch') and pp.lexch:
+            # XC functional - use lexch from raw parser data
+            if lexch:
                 xc = XCFunctional()
-                lexch_code = pp.lexch
+                lexch_code = lexch
 
                 # Map VASP LEXCH codes to standard functional names
                 vasp_xc_map = {
@@ -674,7 +690,8 @@ class OutcarArchiveWriter(ArchiveWriter):
 
         # Post-process pseudopotentials created by mapping annotations
         # This handles complex transformations (type, XC functional, linking)
-        self._process_pseudopotentials(archive_data)
+        # Pass parser data to access lpaw, lultra, lexch flags (not stored in schema)
+        self._process_pseudopotentials(archive_data, source_parser.data)
 
         # assign simulation section to archive data
         self.archive.data = archive_data_parser.data_object

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -11,6 +11,8 @@ from nomad.parsing.file_parser.mapping_parser import MetainfoParser, Path
 from nomad.parsing.file_parser.mapping_parser import TextParser as MappingTextParser
 from nomad.utils import get_logger
 from nomad_simulations.schema_packages.general import Simulation
+from nomad_simulations.schema_packages.model_method import XCFunctional
+from nomad_simulations.schema_packages.numerical_settings import Pseudopotential
 
 from nomad_simulation_parsers.schema_packages import vasp
 
@@ -617,20 +619,29 @@ class OutcarArchiveWriter(ArchiveWriter):
                 pp.gw_optimized = True
 
             # XC functional
-            # TODO: Fix XCFunctional metainfo resolution issue
-            # if 'lexch' in pp_data:
-            #     xc = vasp.XCFunctional()
-            #     lexch_code = pp_data['lexch']
-            #     xc.functional_key = xc_mapping.get(lexch_code, lexch_code)
-            #     pp.xc_functional = xc
+            if 'lexch' in pp_data:
+                xc = XCFunctional()
+                lexch_code = pp_data['lexch']
+                # Store the VASP LEXCH code directly; normalization will expand to LibXC names
+                xc.functional_key = lexch_code
+                pp.xc_functional = xc
 
             # Add to numerical_settings
             if not model_method.numerical_settings:
                 model_method.numerical_settings = []
             model_method.numerical_settings.append(pp)
 
-        # TODO: Link pseudopotentials to AtomsState
-        # Requires fixing metainfo resolution for Pseudopotential reference
+        # Link pseudopotentials to AtomsState
+        # VASP lists pseudopotentials in POSCAR species order
+        if archive_data.model_system and len(archive_data.model_system) > 0:
+            model_system = archive_data.model_system[0]
+            if hasattr(model_system, 'particle_states') and model_system.particle_states:
+                # Get the pseudopotentials we just created
+                created_pseudopotentials = model_method.numerical_settings[-len(pseudopotentials_data):]
+
+                # Link each AtomsState to its corresponding Pseudopotential
+                for atoms_state, pp in zip(model_system.particle_states, created_pseudopotentials):
+                    atoms_state.pseudopotential = pp
 
     def write_to_archive(self) -> None:
         # set up archive parser

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -9,7 +9,6 @@ import numpy as np
 from nomad.parsing.file_parser import ArchiveWriter, Quantity, TextParser
 from nomad.parsing.file_parser.mapping_parser import MetainfoParser, Path
 from nomad.parsing.file_parser.mapping_parser import TextParser as MappingTextParser
-from nomad.units import ureg
 from nomad.utils import get_logger
 from nomad_simulations.schema_packages.general import Simulation
 from nomad_simulations.schema_packages.model_method import XCFunctional
@@ -186,12 +185,16 @@ class OutcarTextParser(TextParser):
                 data['sha256'] = sha256_match.group(1)
 
             # Extract LMAX (number of l-projection operators)
-            lmax_match = re.search(r'number of l-projection\s+operators is LMAX\s*=\s*(\d+)', val_in)
+            lmax_match = re.search(
+                r'number of l-projection\s+operators is LMAX\s*=\s*(\d+)', val_in
+            )
             if lmax_match:
                 data['lmax'] = int(lmax_match.group(1))
 
             # Extract LMMAX (number of lm-projection operators)
-            lmmax_match = re.search(r'number of lm-projection operators is LMMAX\s*=\s*(\d+)', val_in)
+            lmmax_match = re.search(
+                r'number of lm-projection operators is LMMAX\s*=\s*(\d+)', val_in
+            )
             if lmmax_match:
                 data['lmmax'] = int(lmmax_match.group(1))
 
@@ -502,7 +505,9 @@ class OutcarParser(MappingTextParser):
             )
         return data
 
-    def get_pseudopotentials(self, pseudopotentials: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def get_pseudopotentials(
+        self, pseudopotentials: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """
         Filter and return non-empty pseudopotential dictionaries.
 
@@ -589,9 +594,13 @@ class OutcarArchiveWriter(ArchiveWriter):
         # Get pseudopotential data from parser (filter out empty dicts)
         # The OUTCAR parser extracts 4 POTCAR entries but the first 2 are just
         # short header lines without full data
-        raw_pseudopotentials = [pp for pp in parser_data.get('pseudopotentials', []) if pp]
+        raw_pseudopotentials = [
+            pp for pp in parser_data.get('pseudopotentials', []) if pp
+        ]
 
-        pp_index = 0  # Track actual pseudopotential index (skipping non-PP numerical_settings)
+        pp_index = (
+            0  # Track actual pseudopotential index (skipping non-PP numerical_settings)
+        )
         for pp in model_method.numerical_settings:
             # Skip non-pseudopotential numerical settings (if any exist)
             if not isinstance(pp, vasp.Pseudopotential):
@@ -603,7 +612,11 @@ class OutcarArchiveWriter(ArchiveWriter):
 
             # Get lpaw, lultra, lexch from raw parser data (not stored in schema)
             # These flags are used only to derive type and is_norm_conserving
-            raw_pp = raw_pseudopotentials[pp_index] if pp_index < len(raw_pseudopotentials) else {}
+            raw_pp = (
+                raw_pseudopotentials[pp_index]
+                if pp_index < len(raw_pseudopotentials)
+                else {}
+            )
             lpaw = raw_pp.get('lpaw', False)
             lultra = raw_pp.get('lultra', False)
             lexch = raw_pp.get('lexch')
@@ -672,15 +685,21 @@ class OutcarArchiveWriter(ArchiveWriter):
         # VASP lists pseudopotentials in POSCAR species order
         if archive_data.model_system and len(archive_data.model_system) > 0:
             model_system = archive_data.model_system[0]
-            if hasattr(model_system, 'particle_states') and model_system.particle_states:
+            if (
+                hasattr(model_system, 'particle_states')
+                and model_system.particle_states
+            ):
                 # Get only the Pseudopotential objects
                 pseudopotentials = [
-                    ns for ns in model_method.numerical_settings
+                    ns
+                    for ns in model_method.numerical_settings
                     if isinstance(ns, vasp.Pseudopotential)
                 ]
 
                 # Link each AtomsState to its corresponding Pseudopotential
-                for atoms_state, pp in zip(model_system.particle_states, pseudopotentials):
+                for atoms_state, pp in zip(
+                    model_system.particle_states, pseudopotentials
+                ):
                     atoms_state.pseudopotential = pp
 
     def write_to_archive(self) -> None:

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -9,6 +9,7 @@ import numpy as np
 from nomad.parsing.file_parser import ArchiveWriter, Quantity, TextParser
 from nomad.parsing.file_parser.mapping_parser import MetainfoParser, Path
 from nomad.parsing.file_parser.mapping_parser import TextParser as MappingTextParser
+from nomad.units import ureg
 from nomad.utils import get_logger
 from nomad_simulations.schema_packages.general import Simulation
 from nomad_simulations.schema_packages.model_method import XCFunctional
@@ -571,6 +572,7 @@ class OutcarArchiveWriter(ArchiveWriter):
 
         This method handles complex transformations that cannot be expressed
         in declarative mapping annotations:
+        - PPCutoff subsection creation from ENMAX and ENMIN values
         - Type determination (PAW, NC-PAW, US, NC) from LPAW/LULTRA flags
         - is_norm_conserving flag based on type
         - GW optimization detection
@@ -606,17 +608,45 @@ class OutcarArchiveWriter(ArchiveWriter):
             if not isinstance(pp, vasp.Pseudopotential):
                 continue
 
-            # Set cutoff_target (derived field not directly in source data)
-            if pp.enmax:
-                pp.cutoff_target = 'ENMAX'
-
-            # Get lpaw, lultra, lexch from raw parser data (not stored in schema)
-            # These flags are used only to derive type and is_norm_conserving
+            # Create PPCutoff subsections from ENMAX and ENMIN
             raw_pp = (
                 raw_pseudopotentials[pp_index]
                 if pp_index < len(raw_pseudopotentials)
                 else {}
             )
+
+            # ENMAX: recommended cutoff for standard precision
+            if enmax_value := raw_pp.get('enmax'):
+                from nomad_simulations.schema_packages.numerical_settings import (
+                    PPCutoff,
+                )
+
+                enmax_cutoff = PPCutoff(
+                    cutoff_kind='wavefunction',
+                    cutoff_role='recommended',
+                    value=enmax_value * ureg.eV,
+                )
+                if not pp.cutoffs:
+                    pp.cutoffs = []
+                pp.cutoffs.append(enmax_cutoff)
+
+            # ENMIN: minimum recommended cutoff for fast calculations
+            if enmin_value := raw_pp.get('enmin'):
+                from nomad_simulations.schema_packages.numerical_settings import (
+                    PPCutoff,
+                )
+
+                enmin_cutoff = PPCutoff(
+                    cutoff_kind='wavefunction',
+                    cutoff_role='recommended_min',
+                    value=enmin_value * ureg.eV,
+                )
+                if not pp.cutoffs:
+                    pp.cutoffs = []
+                pp.cutoffs.append(enmin_cutoff)
+
+            # Get lpaw, lultra, lexch from raw parser data (not stored in schema)
+            # These flags are used only to derive type and is_norm_conserving
             lpaw = raw_pp.get('lpaw', False)
             lultra = raw_pp.get('lultra', False)
             lexch = raw_pp.get('lexch')

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -9,10 +9,10 @@ import numpy as np
 from nomad.parsing.file_parser import ArchiveWriter, Quantity, TextParser
 from nomad.parsing.file_parser.mapping_parser import MetainfoParser, Path
 from nomad.parsing.file_parser.mapping_parser import TextParser as MappingTextParser
+from nomad.units import ureg
 from nomad.utils import get_logger
 from nomad_simulations.schema_packages.general import Simulation
 from nomad_simulations.schema_packages.model_method import XCFunctional
-from nomad_simulations.schema_packages.numerical_settings import Pseudopotential
 
 from nomad_simulation_parsers.schema_packages import vasp
 
@@ -557,44 +557,17 @@ class OutcarArchiveWriter(ArchiveWriter):
 
         model_method = archive_data.model_method[0]
 
-        # Unit conversion constants:
-        # VASP uses angstroms and eV, schema expects meters and joules
-        ANGSTROM_TO_METER = 1e-10
-        EV_TO_JOULE = 1.602176634e-19
-
-        # Create Pseudopotential instances
         for pp_data in pseudopotentials_data:
             pp = vasp.Pseudopotential()
 
-            # Basic info
-            pp.name = pp_data.get('titel', '')
+            # Use mapping annotation keys (defined in vasp.py with OUTCAR_KEY)
+            # The annotations specify unit conversion, so we pass raw values
+            pp.m_cache = {'OUTCAR_KEY': pp_data}
 
-            # Valence electrons
-            if 'zval' in pp_data:
-                pp.n_valence_electrons = pp_data['zval']
-
-            # Reference configuration
-            if 'vrhfin' in pp_data:
-                pp.reference_configuration = pp_data['vrhfin']
-
-            # Core radius (convert angstroms to meters)
-            if 'rcore' in pp_data:
-                pp.r_core = pp_data['rcore'] * ANGSTROM_TO_METER
-
-            # VASP-specific cutoffs (convert eV to joules)
+            # Fields not covered by mapping annotations:
             if 'enmax' in pp_data:
-                pp.enmax = pp_data['enmax'] * EV_TO_JOULE
-            if 'enmin' in pp_data:
-                pp.enmin = pp_data['enmin'] * EV_TO_JOULE
-
-            # Store representative cutoff (convert eV to joules)
-            if 'enmax' in pp_data:
-                pp.cutoff = pp_data['enmax'] * EV_TO_JOULE
+                pp.cutoff = pp_data['enmax'] * ureg.eV
                 pp.cutoff_target = 'ENMAX'
-
-            # SHA256 hash for unique identification
-            if 'sha256' in pp_data:
-                pp.sha256 = pp_data['sha256']
 
             # Determine type from POTCAR flags and name
             # TODO: Double-check VASP's norm-conserving annotation logic:

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -13,6 +13,7 @@ from nomad.units import ureg
 from nomad.utils import get_logger
 from nomad_simulations.schema_packages.general import Simulation
 from nomad_simulations.schema_packages.model_method import XCFunctional
+from nomad_simulations.schema_packages.numerical_settings import PPCutoff
 
 from nomad_simulation_parsers.schema_packages import vasp
 
@@ -66,7 +67,7 @@ class OutcarTextParser(TextParser):
 
         super().__init__(None)
 
-    def init_quantities(self):
+    def init_quantities(self):  # noqa: PLR0915
         def str_to_array(val_in):
             val = [
                 re.findall(r'(\-?\d+\.[\dEe]+)', v)
@@ -127,7 +128,7 @@ class OutcarTextParser(TextParser):
                 val.extend(['nan' if '*' in v else v for v in line.split()])
             return np.array(val, np.float64)
 
-        def str_to_potcar(val_in):
+        def str_to_potcar(val_in):  # noqa: PLR0912
             """Parse POTCAR header information."""
             data = {}
             # Extract TITEL
@@ -562,7 +563,7 @@ class OutcarParser(MappingTextParser):
 
 
 class OutcarArchiveWriter(ArchiveWriter):
-    def _process_pseudopotentials(
+    def _process_pseudopotentials(  # noqa: PLR0912, PLR0915
         self,
         archive_data: Simulation,
         parser_data: dict[str, Any],
@@ -617,10 +618,6 @@ class OutcarArchiveWriter(ArchiveWriter):
 
             # ENMAX: recommended cutoff for standard precision
             if enmax_value := raw_pp.get('enmax'):
-                from nomad_simulations.schema_packages.numerical_settings import (
-                    PPCutoff,
-                )
-
                 enmax_cutoff = PPCutoff(
                     cutoff_kind='wavefunction',
                     cutoff_role='recommended',
@@ -632,10 +629,6 @@ class OutcarArchiveWriter(ArchiveWriter):
 
             # ENMIN: minimum recommended cutoff for fast calculations
             if enmin_value := raw_pp.get('enmin'):
-                from nomad_simulations.schema_packages.numerical_settings import (
-                    PPCutoff,
-                )
-
                 enmin_cutoff = PPCutoff(
                     cutoff_kind='wavefunction',
                     cutoff_role='recommended_min',

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -125,6 +125,61 @@ class OutcarTextParser(TextParser):
                 val.extend(['nan' if '*' in v else v for v in line.split()])
             return np.array(val, np.float64)
 
+        def str_to_potcar(val_in):
+            """Parse POTCAR header information."""
+            data = {}
+            # Extract TITEL
+            titel_match = re.search(r'TITEL\s*=\s*(.+)', val_in)
+            if titel_match:
+                data['titel'] = titel_match.group(1).strip()
+
+            # Extract VRHFIN (reference configuration)
+            vrhfin_match = re.search(r'VRHFIN\s*=\s*(.+)', val_in)
+            if vrhfin_match:
+                # Extract just the configuration part after the element
+                vrhfin = vrhfin_match.group(1).strip()
+                # Remove element name, keep configuration
+                if ':' in vrhfin:
+                    data['vrhfin'] = vrhfin.split(':', 1)[1].strip()
+                else:
+                    data['vrhfin'] = vrhfin
+
+            # Extract LEXCH (XC functional)
+            lexch_match = re.search(r'LEXCH\s*=\s*(\w+)', val_in)
+            if lexch_match:
+                data['lexch'] = lexch_match.group(1)
+
+            # Extract ZVAL (valence electrons)
+            zval_match = re.search(r'ZVAL\s*=\s*([\d\.]+)', val_in)
+            if zval_match:
+                data['zval'] = float(zval_match.group(1))
+
+            # Extract RCORE (core radius)
+            rcore_match = re.search(r'RCORE\s*=\s*([\d\.]+)', val_in)
+            if rcore_match:
+                data['rcore'] = float(rcore_match.group(1))
+
+            # Extract ENMAX and ENMIN
+            enmax_match = re.search(r'ENMAX\s*=\s*([\d\.]+)', val_in)
+            if enmax_match:
+                data['enmax'] = float(enmax_match.group(1))
+
+            enmin_match = re.search(r'ENMIN\s*=\s*([\d\.]+)', val_in)
+            if enmin_match:
+                data['enmin'] = float(enmin_match.group(1))
+
+            # Extract LPAW (is it PAW?)
+            lpaw_match = re.search(r'LPAW\s*=\s*([TF])', val_in)
+            if lpaw_match:
+                data['lpaw'] = lpaw_match.group(1) == 'T'
+
+            # Extract LULTRA (is it ultrasoft?)
+            lultra_match = re.search(r'LULTRA\s*=\s*([TF])', val_in)
+            if lultra_match:
+                data['lultra'] = lultra_match.group(1) == 'T'
+
+            return data
+
         scf_iteration = [
             Quantity(
                 'energy_total',
@@ -272,6 +327,13 @@ class OutcarTextParser(TextParser):
                 dtype=str,
                 repeats=True,
             ),  # TODO: deprecate
+            Quantity(
+                'pseudopotentials',
+                r'(POTCAR:\s*.+?[\s\S]+?)(?=POTCAR:|end of INCAR parameters|\Z)',
+                repeats=True,
+                str_operation=str_to_potcar,
+                convert=False,
+            ),
             Quantity(
                 'kpoints',
                 r'Following reciprocal coordinates:[\s\S]+?\n([\d\.\s\-]+)',
@@ -467,6 +529,109 @@ class OutcarParser(MappingTextParser):
 
 
 class OutcarArchiveWriter(ArchiveWriter):
+    def _process_pseudopotentials(
+        self,
+        archive_data: Simulation,
+        pseudopotentials_data: list[dict[str, Any]],
+        text_parser: Any,
+    ) -> None:
+        """Process POTCAR information and create Pseudopotential instances."""
+        if not pseudopotentials_data:
+            return
+
+        # Filter out empty dicts (from short POTCAR header lines)
+        pseudopotentials_data = [pp for pp in pseudopotentials_data if pp]
+
+        # Ensure model_method exists
+        if not archive_data.model_method:
+            from nomad_simulations.schema_packages.model_method import ModelMethod
+
+            archive_data.model_method = [ModelMethod()]
+
+        model_method = archive_data.model_method[0]
+
+        # Unit conversion constants:
+        # VASP uses angstroms and eV, schema expects meters and joules
+        ANGSTROM_TO_METER = 1e-10
+        EV_TO_JOULE = 1.602176634e-19
+
+        # Create Pseudopotential instances
+        for pp_data in pseudopotentials_data:
+            pp = vasp.Pseudopotential()
+
+            # Basic info
+            pp.name = pp_data.get('titel', '')
+
+            # Valence electrons
+            if 'zval' in pp_data:
+                pp.n_valence_electrons = pp_data['zval']
+
+            # Reference configuration
+            if 'vrhfin' in pp_data:
+                pp.reference_configuration = pp_data['vrhfin']
+
+            # Core radius (convert angstroms to meters)
+            if 'rcore' in pp_data:
+                pp.r_core = pp_data['rcore'] * ANGSTROM_TO_METER
+
+            # VASP-specific cutoffs (convert eV to joules)
+            if 'enmax' in pp_data:
+                pp.enmax = pp_data['enmax'] * EV_TO_JOULE
+            if 'enmin' in pp_data:
+                pp.enmin = pp_data['enmin'] * EV_TO_JOULE
+
+            # Store representative cutoff (convert eV to joules)
+            if 'enmax' in pp_data:
+                pp.cutoff = pp_data['enmax'] * EV_TO_JOULE
+
+            # Determine type from POTCAR flags and name
+            lpaw = pp_data.get('lpaw', False)
+            lultra = pp_data.get('lultra', False)
+            is_gw = '_GW' in pp_data.get('titel', '')
+
+            if lpaw:
+                # PAW potential
+                if is_gw:
+                    pp.type = 'NC-PAW-GW'
+                    pp.norm_conserving = True  # GW potentials have NC partial waves
+                else:
+                    # Check for NC-PAW variant (rare without GW, but possible)
+                    titel = pp_data.get('titel', '').lower()
+                    if 'nc' in titel and 'paw' in titel:
+                        pp.type = 'NC-PAW'
+                        pp.norm_conserving = True
+                    else:
+                        pp.type = 'PAW'
+                        pp.norm_conserving = False
+            elif lultra:
+                # Ultrasoft (always Vanderbilt formalism)
+                pp.type = 'US'
+                pp.norm_conserving = False
+            else:
+                # Fully norm-conserving (non-PAW, non-ultrasoft)
+                pp.type = 'NC'
+                pp.norm_conserving = True
+
+            # GW optimization detection (keep for backward compatibility)
+            if '_GW' in pp_data.get('titel', ''):
+                pp.gw_optimized = True
+
+            # XC functional
+            # TODO: Fix XCFunctional metainfo resolution issue
+            # if 'lexch' in pp_data:
+            #     xc = vasp.XCFunctional()
+            #     lexch_code = pp_data['lexch']
+            #     xc.functional_key = xc_mapping.get(lexch_code, lexch_code)
+            #     pp.xc_functional = xc
+
+            # Add to numerical_settings
+            if not model_method.numerical_settings:
+                model_method.numerical_settings = []
+            model_method.numerical_settings.append(pp)
+
+        # TODO: Link pseudopotentials to AtomsState
+        # Requires fixing metainfo resolution for Pseudopotential reference
+
     def write_to_archive(self) -> None:
         # set up archive parser
         archive_data_parser = VASPMetainfoParser()
@@ -485,6 +650,13 @@ class OutcarArchiveWriter(ArchiveWriter):
 
         # convert
         source_parser.convert(archive_data_parser)
+
+        # Process pseudopotentials
+        pseudopotentials_data = source_parser.text_parser.get('pseudopotentials', [])
+        if pseudopotentials_data:
+            self._process_pseudopotentials(
+                archive_data, pseudopotentials_data, source_parser.text_parser
+            )
 
         # assign simulation section to archive data
         self.archive.data = archive_data_parser.data_object

--- a/src/nomad_simulation_parsers/parsers/vasp/parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/parser.py
@@ -8,12 +8,11 @@ if TYPE_CHECKING:
         BoundLogger,
     )
 
-from importlib import reload
-
 from nomad.parsing import MatchingParser
 
-from nomad_simulation_parsers.schema_packages import vasp
-from nomad_simulation_parsers.schema_packages.utils import remove_mapping_annotations
+from nomad_simulation_parsers.schema_packages import (
+    vasp,  # noqa: F401 - needed to register mapping annotations
+)
 
 from .outcar_parser import OutcarArchiveWriter
 from .xml_parser import XMLArchiveWriter
@@ -27,8 +26,9 @@ class VASPParser(MatchingParser):
         logger: 'BoundLogger',
         child_archives: dict[str, 'EntryArchive'] = {},
     ) -> None:
-        # reload schema to load vasp annotations
-        reload(vasp)
+        # NOTE: Removed reload(vasp) - it was breaking metainfo registration by creating
+        # new class instances with different m_def objects. The annotations are loaded
+        # when the module is first imported and don't need to be reloaded.
 
         if 'outcar' in mainfile.lower():
             archive_writer = OutcarArchiveWriter()
@@ -36,6 +36,6 @@ class VASPParser(MatchingParser):
             archive_writer = XMLArchiveWriter()
         archive_writer.write(mainfile, archive, logger, child_archives)
 
-        # remove annotations
-        # TODO cache? put in close context
-        remove_mapping_annotations(vasp.general.Simulation.m_def)
+        # NOTE: Removed remove_mapping_annotations() - Since we're no longer reloading,
+        # the annotations are loaded once at module import and should persist across
+        # all parses. Removing them would break subsequent parses.

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -69,7 +69,9 @@ class VasprunParser(XMLParser):
             source, (np.size(source) // int(np.prod(shape_rest)), *shape_rest)
         )
 
-    def get_pseudopotentials(self, atomtypes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def get_pseudopotentials(
+        self, atomtypes: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """
         Extract basic pseudopotential data from vasprun.xml atomtypes array.
 
@@ -112,12 +114,16 @@ class VasprunParser(XMLParser):
             pseudopotentials.append(pp_data)
             LOGGER.debug(f'get_pseudopotentials: Added {pp_data["name"]}')
 
-        LOGGER.debug(f'get_pseudopotentials: Returning {len(pseudopotentials)} pseudopotentials')
+        LOGGER.debug(
+            f'get_pseudopotentials: Returning {len(pseudopotentials)} pseudopotentials'
+        )
         return pseudopotentials
 
 
 class XMLArchiveWriter(ArchiveWriter):
-    def _add_pseudopotentials(self, archive_data: Simulation, xml_parser: VasprunParser) -> None:
+    def _add_pseudopotentials(
+        self, archive_data: Simulation, xml_parser: VasprunParser
+    ) -> None:
         """
         Extract and add basic pseudopotential data from vasprun.xml atomtypes.
 
@@ -180,8 +186,7 @@ class XMLArchiveWriter(ArchiveWriter):
                 pp.name = c_elements[4].strip()
                 pp.n_valence_electrons = float(c_elements[3])
                 model_method.m_add_sub_section(
-                    model_method.m_def.all_sub_sections['numerical_settings'],
-                    pp
+                    model_method.m_def.all_sub_sections['numerical_settings'], pp
                 )
                 LOGGER.debug(f'Added pseudopotential: {pp.name}')
             except (IndexError, ValueError) as e:

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -14,6 +14,10 @@ from nomad_simulation_parsers.schema_packages import vasp
 
 LOGGER = get_logger(__name__)
 
+# Number of expected elements in atomtype rc data:
+# [atomspertype, element, mass, valence, pseudopotential_name]
+ATOMTYPE_RC_EXPECTED_LENGTH = 5
+
 
 # TODO temporary fix for structlog unable to propagate logger
 class VASPMetainfoParser(MetainfoParser):
@@ -103,7 +107,7 @@ class VasprunParser(XMLParser):
             # Extract fields from the rc array structure
             # Format: [atomspertype, element, mass, valence, pseudopotential_name]
             rc = atomtype.get('rc', [])
-            if not rc or len(rc) < 5:
+            if not rc or len(rc) < ATOMTYPE_RC_EXPECTED_LENGTH:
                 LOGGER.debug(f'get_pseudopotentials: Skipping atomtype with rc={rc}')
                 continue
 
@@ -177,7 +181,10 @@ class XMLArchiveWriter(ArchiveWriter):
 
             # rc contains 'c' children with values
             c_elements = rc.get('c', [])
-            if not isinstance(c_elements, list) or len(c_elements) < 5:
+            if (
+                not isinstance(c_elements, list)
+                or len(c_elements) < ATOMTYPE_RC_EXPECTED_LENGTH
+            ):
                 continue
 
             # Extract: [atomspertype, element, mass, valence, pseudopotential_name]

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -84,6 +84,8 @@ class VasprunParser(XMLParser):
         LEXCH, ENMAX, ENMIN, RCORE, VRHFIN, SHA256). These are only available in
         OUTCAR or by parsing POTCAR directly.
         """
+        LOGGER.info(f'get_pseudopotentials called with type: {type(atomtypes)}')
+
         if not atomtypes:
             LOGGER.debug('get_pseudopotentials: No atomtypes provided')
             return []
@@ -91,7 +93,11 @@ class VasprunParser(XMLParser):
         LOGGER.debug(f'get_pseudopotentials: Processing {len(atomtypes)} atomtypes')
 
         pseudopotentials = []
-        for atomtype in atomtypes:
+        for i, atomtype in enumerate(atomtypes):
+            LOGGER.debug(f'Item {i}: type={type(atomtype)}')
+            if isinstance(atomtype, dict):
+                LOGGER.debug(f'  keys: {list(atomtype.keys())}')
+
             # Extract fields from the rc array structure
             # Format: [atomspertype, element, mass, valence, pseudopotential_name]
             rc = atomtype.get('rc', [])
@@ -111,6 +117,76 @@ class VasprunParser(XMLParser):
 
 
 class XMLArchiveWriter(ArchiveWriter):
+    def _add_pseudopotentials(self, archive_data: Simulation, xml_parser: VasprunParser) -> None:
+        """
+        Extract and add basic pseudopotential data from vasprun.xml atomtypes.
+
+        vasprun.xml contains only name and n_valence_electrons, not the detailed
+        POTCAR metadata (LPAW, LULTRA, LEXCH, cutoffs, etc.) needed for type
+        determination. For complete support, parse POTCAR files directly.
+        """
+        if not xml_parser.data:
+            return
+
+        # Navigate to atominfo through modeling
+        modeling = xml_parser.data.get('modeling', {})
+        atominfo = modeling.get('atominfo', {})
+
+        arrays = atominfo.get('array', [])
+        if not isinstance(arrays, list):
+            arrays = [arrays]
+
+        # Find atomtypes array
+        atomtypes_array = None
+        for arr in arrays:
+            if isinstance(arr, dict) and arr.get('@name') == 'atomtypes':
+                atomtypes_array = arr
+                break
+
+        if not atomtypes_array:
+            LOGGER.debug('No atomtypes array found in vasprun.xml')
+            return
+
+        # Extract rc rows from the set
+        set_data = atomtypes_array.get('set', {})
+        rc_rows = set_data.get('rc', [])
+        if not isinstance(rc_rows, list):
+            rc_rows = [rc_rows]
+
+        if not rc_rows:
+            LOGGER.debug('No rc rows in atomtypes')
+            return
+
+        # Ensure model_method exists
+        if not archive_data.model_method or len(archive_data.model_method) == 0:
+            LOGGER.debug('No model_method to attach pseudopotentials to')
+            return
+
+        model_method = archive_data.model_method[0]
+
+        # Create pseudopotentials from rc rows
+        for rc in rc_rows:
+            if not isinstance(rc, dict):
+                continue
+
+            # rc contains 'c' children with values
+            c_elements = rc.get('c', [])
+            if not isinstance(c_elements, list) or len(c_elements) < 5:
+                continue
+
+            # Extract: [atomspertype, element, mass, valence, pseudopotential_name]
+            try:
+                pp = vasp.Pseudopotential()
+                pp.name = c_elements[4].strip()
+                pp.n_valence_electrons = float(c_elements[3])
+                model_method.m_add_sub_section(
+                    model_method.m_def.all_sub_sections['numerical_settings'],
+                    pp
+                )
+                LOGGER.debug(f'Added pseudopotential: {pp.name}')
+            except (IndexError, ValueError) as e:
+                LOGGER.warning(f'Failed to parse pseudopotential from rc: {e}')
+
     def write_to_archive(self) -> None:
         data_parser = VASPMetainfoParser()
         data_parser.data_object = Simulation()
@@ -122,6 +198,9 @@ class XMLArchiveWriter(ArchiveWriter):
 
         data_parser.annotation_key = vasp.XML2_KEY
         xml_parser.convert(data_parser)
+
+        # Add pseudopotentials from atominfo
+        self._add_pseudopotentials(data_parser.data_object, xml_parser)
 
         self.archive.data = data_parser.data_object
 

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -69,6 +69,46 @@ class VasprunParser(XMLParser):
             source, (np.size(source) // int(np.prod(shape_rest)), *shape_rest)
         )
 
+    def get_pseudopotentials(self, atomtypes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """
+        Extract basic pseudopotential data from vasprun.xml atomtypes array.
+
+        The atomtypes array contains:
+        - atomspertype (count)
+        - element
+        - mass
+        - valence (n_valence_electrons)
+        - pseudopotential (name/TITEL)
+
+        Note: vasprun.xml does NOT contain detailed POTCAR metadata (LPAW, LULTRA,
+        LEXCH, ENMAX, ENMIN, RCORE, VRHFIN, SHA256). These are only available in
+        OUTCAR or by parsing POTCAR directly.
+        """
+        if not atomtypes:
+            LOGGER.debug('get_pseudopotentials: No atomtypes provided')
+            return []
+
+        LOGGER.debug(f'get_pseudopotentials: Processing {len(atomtypes)} atomtypes')
+
+        pseudopotentials = []
+        for atomtype in atomtypes:
+            # Extract fields from the rc array structure
+            # Format: [atomspertype, element, mass, valence, pseudopotential_name]
+            rc = atomtype.get('rc', [])
+            if not rc or len(rc) < 5:
+                LOGGER.debug(f'get_pseudopotentials: Skipping atomtype with rc={rc}')
+                continue
+
+            pp_data = {
+                'name': rc[4].strip(),  # pseudopotential name (TITEL)
+                'n_valence_electrons': float(rc[3]),  # valence
+            }
+            pseudopotentials.append(pp_data)
+            LOGGER.debug(f'get_pseudopotentials: Added {pp_data["name"]}')
+
+        LOGGER.debug(f'get_pseudopotentials: Returning {len(pseudopotentials)} pseudopotentials')
+        return pseudopotentials
+
 
 class XMLArchiveWriter(ArchiveWriter):
     def write_to_archive(self) -> None:
@@ -84,6 +124,13 @@ class XMLArchiveWriter(ArchiveWriter):
         xml_parser.convert(data_parser)
 
         self.archive.data = data_parser.data_object
+
+        # TODO: Add POTCAR parser for complete pseudopotential metadata
+        # Currently vasprun.xml provides only basic info (name, valence) while OUTCAR
+        # contains full POTCAR headers. Direct POTCAR parsing would enable complete
+        # pseudopotential support (LPAW, LULTRA, LEXCH, ENMAX/ENMIN, RCORE, VRHFIN,
+        # SHA256) regardless of which mainfile is used. This would allow proper type
+        # determination and XC functional resolution from vasprun.xml-only uploads.
 
         # close file objects
         data_parser.close()

--- a/src/nomad_simulation_parsers/parsers/wannier90/parser.py
+++ b/src/nomad_simulation_parsers/parsers/wannier90/parser.py
@@ -1,7 +1,6 @@
 import os
 import re
 from collections.abc import Iterable
-from importlib import reload
 from typing import Any
 
 import numpy as np
@@ -481,9 +480,6 @@ class WannierArchiveWriter(ArchiveWriter):
         wband_parser.close()
 
     def write_to_archive(self) -> None:
-        # reload the schema annotations
-        reload(wannier90)
-
         self.basename = os.path.basename(self.mainfile)
         self.basedir = os.path.dirname(self.mainfile)
         # define mapping parser interface to OutParser

--- a/src/nomad_simulation_parsers/schema_packages/utils.py
+++ b/src/nomad_simulation_parsers/schema_packages/utils.py
@@ -5,45 +5,6 @@ from nomad.metainfo import Quantity, Section, SubSection
 from nomad.parsing.file_parser.mapping_parser import MAPPING_ANNOTATION_KEY
 
 
-def remove_mapping_annotations(property: Section, max_depth: int = 5) -> None:
-    """
-    Remove mapping annotations from the input section definition, all its quantities
-    and sub-sections recursively.
-    Args:
-        property (Section): The section definition to remove the annotations from.
-        max_depth (int, optional): The maximum depth of the recursion for sub-sections
-            using the same section as parent.
-    """
-
-    def _remove(property: Section | SubSection, depth: int = 0):
-        if depth > max_depth:
-            return
-
-        annotation_key = 'mapping'
-        property.m_annotations.pop(annotation_key, None)
-
-        depth += 1
-        property_section = (
-            property.sub_section if isinstance(property, SubSection) else property
-        )
-        for quantity in property_section.all_quantities.values():
-            quantity.m_annotations.pop(annotation_key, None)
-
-        for sub_section in property_section.all_sub_sections.values():
-            if sub_section.m_annotations.get(annotation_key):
-                _remove(sub_section, depth)
-            elif sub_section.sub_section.m_annotations.get(annotation_key):
-                _remove(sub_section.sub_section, depth)
-            else:
-                for (
-                    inheriting_section
-                ) in sub_section.sub_section.all_inheriting_sections:
-                    if inheriting_section.m_annotations.get(annotation_key):
-                        _remove(inheriting_section, depth)
-
-    _remove(property)
-
-
 def add_mapping_annotation(
     property: Section | Quantity | SubSection,
     annotation_key: str,

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -35,7 +35,7 @@ class Simulation(general.Simulation):
     add_mapping_annotation(
         model_method.DFT.m_def,
         XML_KEY,
-        '.parameters.separator[?"@name"==\'electronic\']',
+        '.parameters',
     )
     add_mapping_annotation(model_method.DFT.m_def, OUTCAR_KEY, 'parameters')
     # Note: Pseudopotential.m_def mapping added after Pseudopotential class definition
@@ -232,10 +232,11 @@ add_mapping_annotation(
 # XML mapping: Extract basic pseudopotential data from atomtypes array
 # Note: vasprun.xml only contains name and n_valence_electrons, not detailed
 # POTCAR metadata (LPAW, LULTRA, LEXCH, cutoffs, etc.)
+# TODO: Fix jmespath to correctly extract atomtypes.set.rc data structure
 add_mapping_annotation(
     Pseudopotential.m_def,
     XML_KEY,
-    ('get_pseudopotentials', ['@.atominfo.array[?"@name"==\'atomtypes\'].set.rc']),
+    ('get_pseudopotentials', ['@.atominfo.array[?"@name"==\'atomtypes\']']),
 )
 
 

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -24,7 +24,7 @@ OUTCAR_KEY = 'outcar'
 
 add_mapping_annotation(general.Simulation.m_def, XML_KEY, 'modeling')
 add_mapping_annotation(general.Simulation.m_def, XML2_KEY, 'modeling')
-add_mapping_annotation(general.Simulation.m_def, OUTCAR_KEY, '.')
+add_mapping_annotation(general.Simulation.m_def, OUTCAR_KEY, '@')
 
 
 class Simulation(general.Simulation):

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -130,29 +130,8 @@ class KMesh(numerical_settings.KMesh):
 
 class Pseudopotential(numerical_settings.Pseudopotential):
     """
-    VASP-specific pseudopotential extension with ENMAX/ENMIN cutoffs.
+    VASP-specific pseudopotential extension with ENMAX/ENMIN cutoff metadata.
     """
-
-    enmax = Quantity(
-        type=np.float64,
-        unit='joule',
-        description="""
-        Maximum cutoff energy (ENMAX) recommended for this pseudopotential.
-        This is the standard cutoff used for high-precision calculations.
-        """,
-    )
-
-    enmin = Quantity(
-        type=np.float64,
-        unit='joule',
-        description="""
-        Minimum cutoff energy (ENMIN) for low-precision calculations.
-        Typically about 2/3 of ENMAX.
-        """,
-    )
-
-    cutoff_target = numerical_settings.Pseudopotential.cutoff_target.m_copy()
-    cutoff_target.default = 'ENMAX'
 
     sha256 = Quantity(
         type=str,
@@ -176,15 +155,15 @@ class Pseudopotential(numerical_settings.Pseudopotential):
         type=np.int32,
         description="""
         Total number of lm-projection operators.
-        This is the sum over all angular momentum channels of (2l+1) for each l up to lmax.
-        Determines the completeness of the PAW reconstruction.
+        This is the sum over all angular momentum channels of (2l+1) for each l
+        up to lmax. Determines the completeness of the PAW reconstruction.
         """,
     )
 
     # Note: lpaw, lultra, lexch are extracted during parsing but not stored in schema.
     # They're used internally by the parser to derive `type` and `is_norm_conserving`.
 
-    # Mapping annotations will be added here
+    # Mapping annotations
     # OUTCAR provides complete POTCAR metadata
     add_mapping_annotation(
         numerical_settings.Pseudopotential.name, OUTCAR_KEY, '.titel'
@@ -207,20 +186,18 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     add_mapping_annotation(
         numerical_settings.Pseudopotential.r_core, OUTCAR_KEY, '.rcore', unit='angstrom'
     )
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.cutoff, OUTCAR_KEY, '.enmax', unit='eV'
-    )
-    add_mapping_annotation(enmax, OUTCAR_KEY, '.enmax', unit='eV')
-    add_mapping_annotation(enmin, OUTCAR_KEY, '.enmin', unit='eV')
+    # PPCutoff subsections - ENMAX and ENMIN will be populated via custom parser logic
+    # in get_pseudopotentials() rather than direct mapping annotations
     add_mapping_annotation(sha256, OUTCAR_KEY, '.sha256')
     add_mapping_annotation(lmax, OUTCAR_KEY, '.lmax')
     add_mapping_annotation(lmmax, OUTCAR_KEY, '.lmmax')
     # Note: lpaw, lultra, lexch are NOT mapped to schema - they're used internally
-    # by the parser's _process_pseudopotentials method to derive type and is_norm_conserving
+    # by the parser's _process_pseudopotentials method to derive type and
+    # is_norm_conserving
 
 
 # Pseudopotential collection mapping - must be after Pseudopotential class definition
-# to use the VASP-specific extension with enmax, enmin, sha256 fields
+# to use the VASP-specific extension with sha256, lmax, lmmax fields
 add_mapping_annotation(
     Pseudopotential.m_def,
     OUTCAR_KEY,

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -150,6 +150,18 @@ class Pseudopotential(numerical_settings.Pseudopotential):
         """,
     )
 
+    cutoff_target = numerical_settings.Pseudopotential.cutoff_target.m_copy()
+    cutoff_target.default = 'ENMAX'
+
+    sha256 = Quantity(
+        type=str,
+        description="""
+        SHA256 hash of the POTCAR file for unique identification.
+        This allows verification of pseudopotential provenance and ensures
+        reproducibility by confirming the exact pseudopotential file used.
+        """,
+    )
+
     # Mapping annotations will be added here
     add_mapping_annotation(
         numerical_settings.Pseudopotential.name, OUTCAR_KEY, '.titel'
@@ -167,6 +179,7 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     )
     add_mapping_annotation(enmax, OUTCAR_KEY, '.enmax', unit='eV')
     add_mapping_annotation(enmin, OUTCAR_KEY, '.enmin', unit='eV')
+    add_mapping_annotation(sha256, OUTCAR_KEY, '.sha256')
 
 
 class ModelSystem(model_system.ModelSystem):

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -188,11 +188,19 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     )
 
     # Mapping annotations will be added here
+    # OUTCAR provides complete POTCAR metadata
     add_mapping_annotation(
         numerical_settings.Pseudopotential.name, OUTCAR_KEY, '.titel'
     )
     add_mapping_annotation(
         numerical_settings.Pseudopotential.n_valence_electrons, OUTCAR_KEY, '.zval'
+    )
+    # vasprun.xml provides basic pseudopotential info (name and valence only)
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.name, XML_KEY, '.name'
+    )
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.n_valence_electrons, XML_KEY, '.n_valence_electrons'
     )
     add_mapping_annotation(
         numerical_settings.Pseudopotential.reference_configuration,
@@ -219,6 +227,15 @@ add_mapping_annotation(
     Pseudopotential.m_def,
     OUTCAR_KEY,
     ('get_pseudopotentials', ['@.pseudopotentials']),
+)
+
+# XML mapping: Extract basic pseudopotential data from atomtypes array
+# Note: vasprun.xml only contains name and n_valence_electrons, not detailed
+# POTCAR metadata (LPAW, LULTRA, LEXCH, cutoffs, etc.)
+add_mapping_annotation(
+    Pseudopotential.m_def,
+    XML_KEY,
+    ('get_pseudopotentials', ['@.atominfo.array[?"@name"==\'atomtypes\'].set.rc']),
 )
 
 

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -38,6 +38,7 @@ class Simulation(general.Simulation):
         '.parameters.separator[?"@name"==\'electronic\']',
     )
     add_mapping_annotation(model_method.DFT.m_def, OUTCAR_KEY, 'parameters')
+    # Note: Pseudopotential.m_def mapping added after Pseudopotential class definition
     add_mapping_annotation(general.Simulation.model_system, XML_KEY, '.calculation')
     add_mapping_annotation(general.Simulation.model_system, OUTCAR_KEY, '.calculation')
     add_mapping_annotation(general.Simulation.outputs, XML_KEY, '.calculation')
@@ -177,9 +178,21 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     add_mapping_annotation(
         numerical_settings.Pseudopotential.r_core, OUTCAR_KEY, '.rcore', unit='angstrom'
     )
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.cutoff, OUTCAR_KEY, '.enmax', unit='eV'
+    )
     add_mapping_annotation(enmax, OUTCAR_KEY, '.enmax', unit='eV')
     add_mapping_annotation(enmin, OUTCAR_KEY, '.enmin', unit='eV')
     add_mapping_annotation(sha256, OUTCAR_KEY, '.sha256')
+
+
+# Pseudopotential collection mapping - must be after Pseudopotential class definition
+# to use the VASP-specific extension with enmax, enmin, sha256 fields
+add_mapping_annotation(
+    Pseudopotential.m_def,
+    OUTCAR_KEY,
+    ('get_pseudopotentials', ['@.pseudopotentials']),
+)
 
 
 class ModelSystem(model_system.ModelSystem):

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -24,7 +24,7 @@ OUTCAR_KEY = 'outcar'
 
 add_mapping_annotation(general.Simulation.m_def, XML_KEY, 'modeling')
 add_mapping_annotation(general.Simulation.m_def, XML2_KEY, 'modeling')
-add_mapping_annotation(general.Simulation.m_def, OUTCAR_KEY, '@')
+add_mapping_annotation(general.Simulation.m_def, OUTCAR_KEY, '.')
 
 
 class Simulation(general.Simulation):

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -163,6 +163,24 @@ class Pseudopotential(numerical_settings.Pseudopotential):
         """,
     )
 
+    lmax = Quantity(
+        type=np.int32,
+        description="""
+        Maximum angular momentum quantum number (l) for projection operators.
+        Indicates the highest angular momentum channel included in the pseudopotential.
+        Typical values: 4-6 for transition metals, 2-4 for lighter elements.
+        """,
+    )
+
+    lmmax = Quantity(
+        type=np.int32,
+        description="""
+        Total number of lm-projection operators.
+        This is the sum over all angular momentum channels of (2l+1) for each l up to lmax.
+        Determines the completeness of the PAW reconstruction.
+        """,
+    )
+
     # Note: lpaw, lultra, lexch are extracted during parsing but not stored in schema.
     # They're used internally by the parser to derive `type` and `is_norm_conserving`.
 
@@ -195,6 +213,8 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     add_mapping_annotation(enmax, OUTCAR_KEY, '.enmax', unit='eV')
     add_mapping_annotation(enmin, OUTCAR_KEY, '.enmin', unit='eV')
     add_mapping_annotation(sha256, OUTCAR_KEY, '.sha256')
+    add_mapping_annotation(lmax, OUTCAR_KEY, '.lmax')
+    add_mapping_annotation(lmmax, OUTCAR_KEY, '.lmmax')
     # Note: lpaw, lultra, lexch are NOT mapped to schema - they're used internally
     # by the parser's _process_pseudopotentials method to derive type and is_norm_conserving
 

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -36,7 +36,7 @@ class Simulation(general.Simulation):
         XML_KEY,
         '.parameters',
     )
-    add_mapping_annotation(model_method.DFT.m_def, OUTCAR_KEY, 'parameters')
+    add_mapping_annotation(model_method.DFT.m_def, OUTCAR_KEY, '.parameters')
     # NOTE: Pseudopotential annotations registered after class definition (line 203)
     # Ensures proper parser hierarchy: Simulation -> ModelMethod -> NumericalSettings
     add_mapping_annotation(general.Simulation.model_system, XML_KEY, '.calculation')

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -3,7 +3,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     pass
 
-from nomad.metainfo import SchemaPackage
+import numpy as np
+from nomad.metainfo import Quantity, SchemaPackage
 from nomad_simulations.schema_packages import (
     general,
     model_method,
@@ -124,6 +125,48 @@ class KMesh(numerical_settings.KMesh):
             dict(shape_rest=()),
         ),
     )
+
+
+class Pseudopotential(numerical_settings.Pseudopotential):
+    """
+    VASP-specific pseudopotential extension with ENMAX/ENMIN cutoffs.
+    """
+
+    enmax = Quantity(
+        type=np.float64,
+        unit='joule',
+        description="""
+        Maximum cutoff energy (ENMAX) recommended for this pseudopotential.
+        This is the standard cutoff used for high-precision calculations.
+        """,
+    )
+
+    enmin = Quantity(
+        type=np.float64,
+        unit='joule',
+        description="""
+        Minimum cutoff energy (ENMIN) for low-precision calculations.
+        Typically about 2/3 of ENMAX.
+        """,
+    )
+
+    # Mapping annotations will be added here
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.name, OUTCAR_KEY, '.titel'
+    )
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.n_valence_electrons, OUTCAR_KEY, '.zval'
+    )
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.reference_configuration,
+        OUTCAR_KEY,
+        '.vrhfin',
+    )
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.r_core, OUTCAR_KEY, '.rcore', unit='angstrom'
+    )
+    add_mapping_annotation(enmax, OUTCAR_KEY, '.enmax', unit='eV')
+    add_mapping_annotation(enmin, OUTCAR_KEY, '.enmin', unit='eV')
 
 
 class ModelSystem(model_system.ModelSystem):

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     pass
 
-import numpy as np
 from nomad.metainfo import Quantity, SchemaPackage
 from nomad_simulations.schema_packages import (
     general,
@@ -40,6 +39,7 @@ class Simulation(general.Simulation):
     add_mapping_annotation(model_method.DFT.m_def, OUTCAR_KEY, 'parameters')
     # NOTE: Pseudopotential annotations registered after class definition (line 203)
     # Ensures proper parser hierarchy: Simulation -> ModelMethod -> NumericalSettings
+    add_mapping_annotation(general.Simulation.model_method, OUTCAR_KEY, '.@')
     add_mapping_annotation(general.Simulation.model_system, XML_KEY, '.calculation')
     add_mapping_annotation(general.Simulation.model_system, OUTCAR_KEY, '.calculation')
     add_mapping_annotation(general.Simulation.outputs, XML_KEY, '.calculation')
@@ -145,24 +145,6 @@ class Pseudopotential(numerical_settings.Pseudopotential):
         """,
     )
 
-    lmax = Quantity(
-        type=np.int32,
-        description="""
-        Maximum angular momentum quantum number (l) for projection operators.
-        Indicates the highest angular momentum channel included in the pseudopotential.
-        Typical values: 4-6 for transition metals, 2-4 for lighter elements.
-        """,
-    )
-
-    lmmax = Quantity(
-        type=np.int32,
-        description="""
-        Total number of lm-projection operators.
-        This is the sum over all angular momentum channels of (2l+1) for each l
-        up to lmax. Determines the completeness of the PAW reconstruction.
-        """,
-    )
-
     # Note: lpaw, lultra, lexch are extracted during parsing but not stored in schema.
     # They're used internally by the parser to derive `type` and `is_norm_conserving`.
 
@@ -189,18 +171,18 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     add_mapping_annotation(
         numerical_settings.Pseudopotential.r_core, OUTCAR_KEY, '.rcore', unit='angstrom'
     )
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.l_max, OUTCAR_KEY, '.lmax'
+    )
+    add_mapping_annotation(
+        numerical_settings.Pseudopotential.lm_max, OUTCAR_KEY, '.lmmax'
+    )
     # PPCutoff subsections - ENMAX and ENMIN will be populated via custom parser logic
     # in get_pseudopotentials() rather than direct mapping annotations
     add_mapping_annotation(sha256, OUTCAR_KEY, '.sha256')
-    add_mapping_annotation(lmax, OUTCAR_KEY, '.lmax')
-    add_mapping_annotation(lmmax, OUTCAR_KEY, '.lmmax')
-    # Note: lpaw, lultra, lexch are NOT mapped to schema - they're used internally
-    # by the parser's _process_pseudopotentials method to derive type and
-    # is_norm_conserving
 
 
 # Pseudopotential collection mapping - must be after Pseudopotential class definition
-# to use the VASP-specific extension with sha256, lmax, lmmax fields
 # These annotations are added in the context of ModelMethod to ensure the parser
 # creates Pseudopotential subsections in model_method.numerical_settings
 add_mapping_annotation(

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -163,29 +163,8 @@ class Pseudopotential(numerical_settings.Pseudopotential):
         """,
     )
 
-    lpaw = Quantity(
-        type=bool,
-        description="""
-        LPAW flag from POTCAR indicating if this is a PAW pseudopotential.
-        Used internally for type determination.
-        """,
-    )
-
-    lultra = Quantity(
-        type=bool,
-        description="""
-        LULTRA flag from POTCAR indicating if this is an ultrasoft pseudopotential.
-        Used internally for type determination.
-        """,
-    )
-
-    lexch = Quantity(
-        type=str,
-        description="""
-        LEXCH code from POTCAR indicating the XC functional (e.g., 'PE' for PBE).
-        Used internally for XC functional determination.
-        """,
-    )
+    # Note: lpaw, lultra, lexch are extracted during parsing but not stored in schema.
+    # They're used internally by the parser to derive `type` and `is_norm_conserving`.
 
     # Mapping annotations will be added here
     # OUTCAR provides complete POTCAR metadata
@@ -216,9 +195,8 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     add_mapping_annotation(enmax, OUTCAR_KEY, '.enmax', unit='eV')
     add_mapping_annotation(enmin, OUTCAR_KEY, '.enmin', unit='eV')
     add_mapping_annotation(sha256, OUTCAR_KEY, '.sha256')
-    add_mapping_annotation(lpaw, OUTCAR_KEY, '.lpaw')
-    add_mapping_annotation(lultra, OUTCAR_KEY, '.lultra')
-    add_mapping_annotation(lexch, OUTCAR_KEY, '.lexch')
+    # Note: lpaw, lultra, lexch are NOT mapped to schema - they're used internally
+    # by the parser's _process_pseudopotentials method to derive type and is_norm_conserving
 
 
 # Pseudopotential collection mapping - must be after Pseudopotential class definition

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -163,6 +163,30 @@ class Pseudopotential(numerical_settings.Pseudopotential):
         """,
     )
 
+    lpaw = Quantity(
+        type=bool,
+        description="""
+        LPAW flag from POTCAR indicating if this is a PAW pseudopotential.
+        Used internally for type determination.
+        """,
+    )
+
+    lultra = Quantity(
+        type=bool,
+        description="""
+        LULTRA flag from POTCAR indicating if this is an ultrasoft pseudopotential.
+        Used internally for type determination.
+        """,
+    )
+
+    lexch = Quantity(
+        type=str,
+        description="""
+        LEXCH code from POTCAR indicating the XC functional (e.g., 'PE' for PBE).
+        Used internally for XC functional determination.
+        """,
+    )
+
     # Mapping annotations will be added here
     add_mapping_annotation(
         numerical_settings.Pseudopotential.name, OUTCAR_KEY, '.titel'
@@ -184,6 +208,9 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     add_mapping_annotation(enmax, OUTCAR_KEY, '.enmax', unit='eV')
     add_mapping_annotation(enmin, OUTCAR_KEY, '.enmin', unit='eV')
     add_mapping_annotation(sha256, OUTCAR_KEY, '.sha256')
+    add_mapping_annotation(lpaw, OUTCAR_KEY, '.lpaw')
+    add_mapping_annotation(lultra, OUTCAR_KEY, '.lultra')
+    add_mapping_annotation(lexch, OUTCAR_KEY, '.lexch')
 
 
 # Pseudopotential collection mapping - must be after Pseudopotential class definition

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -38,7 +38,8 @@ class Simulation(general.Simulation):
         '.parameters',
     )
     add_mapping_annotation(model_method.DFT.m_def, OUTCAR_KEY, 'parameters')
-    # Note: Pseudopotential.m_def mapping added after Pseudopotential class definition
+    # NOTE: Pseudopotential annotations registered after class definition (line 203)
+    # Ensures proper parser hierarchy: Simulation -> ModelMethod -> NumericalSettings
     add_mapping_annotation(general.Simulation.model_system, XML_KEY, '.calculation')
     add_mapping_annotation(general.Simulation.model_system, OUTCAR_KEY, '.calculation')
     add_mapping_annotation(general.Simulation.outputs, XML_KEY, '.calculation')
@@ -91,6 +92,8 @@ class XCComponent(model_method.XCComponent):
 class ModelMethod(model_method.ModelMethod):
     # kspace numerical settings
     add_mapping_annotation(numerical_settings.KSpace.m_def, XML_KEY, 'modeling.kpoints')
+    # TODO: Add KSpace mapping for OUTCAR k-points
+    # add_mapping_annotation(numerical_settings.KSpace.m_def, OUTCAR_KEY, '@')
 
 
 class KSpace(numerical_settings.KSpace):
@@ -198,6 +201,8 @@ class Pseudopotential(numerical_settings.Pseudopotential):
 
 # Pseudopotential collection mapping - must be after Pseudopotential class definition
 # to use the VASP-specific extension with sha256, lmax, lmmax fields
+# These annotations are added in the context of ModelMethod to ensure the parser
+# creates Pseudopotential subsections in model_method.numerical_settings
 add_mapping_annotation(
     Pseudopotential.m_def,
     OUTCAR_KEY,

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -147,58 +147,43 @@ class Pseudopotential(numerical_settings.Pseudopotential):
     # Note: lpaw, lultra, lexch are extracted during parsing but not stored in schema.
     # They're used internally by the parser to derive `type` and `is_norm_conserving`.
 
-    # Mapping annotations
-    # OUTCAR provides complete POTCAR metadata
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.name, OUTCAR_KEY, '.titel'
-    )
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.n_valence_electrons, OUTCAR_KEY, '.zval'
-    )
-    # vasprun.xml provides basic pseudopotential info (name and valence only)
-    add_mapping_annotation(numerical_settings.Pseudopotential.name, XML_KEY, '.name')
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.n_valence_electrons,
-        XML_KEY,
-        '.n_valence_electrons',
-    )
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.reference_configuration,
-        OUTCAR_KEY,
-        '.vrhfin',
-    )
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.r_core, OUTCAR_KEY, '.rcore', unit='angstrom'
-    )
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.l_max, OUTCAR_KEY, '.lmax'
-    )
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.lm_max, OUTCAR_KEY, '.lmmax'
-    )
-    # PPCutoff subsections - ENMAX and ENMIN will be populated via custom parser logic
-    # in get_pseudopotentials() rather than direct mapping annotations
-    add_mapping_annotation(sha256, OUTCAR_KEY, '.sha256')
+    # NOTE: Mapping annotations moved to after class definition to reference
+    # Pseudopotential.property instead of base class properties, making VASP
+    # immune to annotation contamination from other parsers
 
 
-# Pseudopotential collection mapping - must be after Pseudopotential class definition
-# These annotations are added in the context of ModelMethod to ensure the parser
-# creates Pseudopotential subsections in model_method.numerical_settings
+# Pseudopotential mapping annotations - AFTER class definition to reference VASP-specific
+# inherited properties instead of base class properties. This makes VASP immune to
+# contamination from other parsers removing base class annotations.
+
+# Collection mapping - tells parser to create Pseudopotential instances
 add_mapping_annotation(
     Pseudopotential.m_def,
     OUTCAR_KEY,
     ('get_pseudopotentials', ['@.pseudopotentials']),
 )
-
-# XML mapping: Extract basic pseudopotential data from atomtypes array
-# Note: vasprun.xml only contains name and n_valence_electrons, not detailed
-# POTCAR metadata (LPAW, LULTRA, LEXCH, cutoffs, etc.)
-# TODO: Fix jmespath to correctly extract atomtypes.set.rc data structure
 add_mapping_annotation(
     Pseudopotential.m_def,
     XML_KEY,
     ('get_pseudopotentials', ['@.atominfo.array[?"@name"==\'atomtypes\']']),
 )
+
+# Property mappings - using Pseudopotential.property (VASP-specific inherited properties)
+# instead of numerical_settings.Pseudopotential.property (base class properties).
+# This isolates VASP from contamination when other parsers remove base class annotations.
+
+# OUTCAR provides complete POTCAR metadata
+add_mapping_annotation(Pseudopotential.name, OUTCAR_KEY, '.titel')
+add_mapping_annotation(Pseudopotential.n_valence_electrons, OUTCAR_KEY, '.zval')
+add_mapping_annotation(Pseudopotential.reference_configuration, OUTCAR_KEY, '.vrhfin')
+add_mapping_annotation(Pseudopotential.r_core, OUTCAR_KEY, '.rcore', unit='angstrom')
+add_mapping_annotation(Pseudopotential.l_max, OUTCAR_KEY, '.lmax')
+add_mapping_annotation(Pseudopotential.lm_max, OUTCAR_KEY, '.lmmax')
+add_mapping_annotation(Pseudopotential.sha256, OUTCAR_KEY, '.sha256')
+
+# vasprun.xml provides basic pseudopotential info (name and valence only)
+add_mapping_annotation(Pseudopotential.name, XML_KEY, '.name')
+add_mapping_annotation(Pseudopotential.n_valence_electrons, XML_KEY, '.n_valence_electrons')
 
 
 class ModelSystem(model_system.ModelSystem):

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -193,11 +193,11 @@ class Pseudopotential(numerical_settings.Pseudopotential):
         numerical_settings.Pseudopotential.n_valence_electrons, OUTCAR_KEY, '.zval'
     )
     # vasprun.xml provides basic pseudopotential info (name and valence only)
+    add_mapping_annotation(numerical_settings.Pseudopotential.name, XML_KEY, '.name')
     add_mapping_annotation(
-        numerical_settings.Pseudopotential.name, XML_KEY, '.name'
-    )
-    add_mapping_annotation(
-        numerical_settings.Pseudopotential.n_valence_electrons, XML_KEY, '.n_valence_electrons'
+        numerical_settings.Pseudopotential.n_valence_electrons,
+        XML_KEY,
+        '.n_valence_electrons',
     )
     add_mapping_annotation(
         numerical_settings.Pseudopotential.reference_configuration,

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -39,7 +39,6 @@ class Simulation(general.Simulation):
     add_mapping_annotation(model_method.DFT.m_def, OUTCAR_KEY, 'parameters')
     # NOTE: Pseudopotential annotations registered after class definition (line 203)
     # Ensures proper parser hierarchy: Simulation -> ModelMethod -> NumericalSettings
-    add_mapping_annotation(general.Simulation.model_method, OUTCAR_KEY, '.@')
     add_mapping_annotation(general.Simulation.model_system, XML_KEY, '.calculation')
     add_mapping_annotation(general.Simulation.model_system, OUTCAR_KEY, '.calculation')
     add_mapping_annotation(general.Simulation.outputs, XML_KEY, '.calculation')

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -21,7 +21,6 @@ def test_outcar():
     parser.parse('tests/data/vasp/AgAc_relax/OUTCAR', archive, LOGGER)
 
     simulation = archive.data
-    print(simulation)
     assert simulation is not None, 'No simulation data in archive'
 
     assert simulation.model_method, 'No model_method in simulation'

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -11,26 +11,8 @@ def test_vasprun():
     archive = EntryArchive()
     parser.parse('tests/data/vasp/AgAc_relax/vasprun.xml.relax', archive, LOGGER)
 
-    # Check numerical_settings structure
     simulation = archive.data
     assert simulation is not None
-
-    LOGGER.info('\n=== vasprun.xml structure ===')
-    if hasattr(simulation, 'model_method') and simulation.model_method:
-        for method in simulation.model_method:
-            LOGGER.info(f'ModelMethod type: {type(method).__name__}')
-            if hasattr(method, 'numerical_settings') and method.numerical_settings:
-                LOGGER.info(
-                    f'Found {len(method.numerical_settings)} numerical_settings'
-                )
-                for ns in method.numerical_settings:
-                    LOGGER.info(f'  - {type(ns).__name__}')
-                    if hasattr(ns, 'pseudopotential') and ns.pseudopotential:
-                        LOGGER.info(
-                            f'    Contains {len(ns.pseudopotential)} pseudopotentials'
-                        )
-                        for pp in ns.pseudopotential:
-                            LOGGER.info(f'      * {pp.name}')
 
 
 def test_outcar():
@@ -38,7 +20,6 @@ def test_outcar():
     archive = EntryArchive()
     parser.parse('tests/data/vasp/AgAc_relax/OUTCAR', archive, LOGGER)
 
-    # Verify numerical_settings are present
     simulation = archive.data
     assert simulation is not None, 'No simulation data in archive'
     assert simulation.model_method, 'No model_method in simulation'
@@ -50,19 +31,13 @@ def test_outcar():
     assert method.numerical_settings is not None, 'numerical_settings is None'
     assert len(method.numerical_settings) > 0, 'numerical_settings is empty'
 
-    LOGGER.info(f'Found {len(method.numerical_settings)} numerical_settings')
-
     # Check for Pseudopotentials
     pseudopotentials = [
         ns for ns in method.numerical_settings if type(ns).__name__ == 'Pseudopotential'
     ]
     assert len(pseudopotentials) > 0, 'No Pseudopotential objects in numerical_settings'
 
-    LOGGER.info(f'Found {len(pseudopotentials)} Pseudopotentials:')
+    # Verify OUTCAR-specific fields are populated
     for pp in pseudopotentials:
-        LOGGER.info(f'  - {pp.name}: {pp.n_valence_electrons} valence electrons')
-        # Verify OUTCAR-specific fields are populated
-        if pp.sha256:
-            LOGGER.info(f'    SHA256: {pp.sha256[:16]}...')
-        if pp.l_max is not None:
-            LOGGER.info(f'    l_max: {pp.l_max}')
+        assert pp.name is not None
+        assert pp.n_valence_electrons is not None

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -64,5 +64,5 @@ def test_outcar():
         # Verify OUTCAR-specific fields are populated
         if pp.sha256:
             LOGGER.info(f'    SHA256: {pp.sha256[:16]}...')
-        if pp.lmax is not None:
-            LOGGER.info(f'    lmax: {pp.lmax}')
+        if pp.l_max is not None:
+            LOGGER.info(f'    l_max: {pp.l_max}')

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -11,8 +11,58 @@ def test_vasprun():
     archive = EntryArchive()
     parser.parse('tests/data/vasp/AgAc_relax/vasprun.xml.relax', archive, LOGGER)
 
+    # Check numerical_settings structure
+    simulation = archive.data
+    assert simulation is not None
+
+    LOGGER.info('\n=== vasprun.xml structure ===')
+    if hasattr(simulation, 'model_method') and simulation.model_method:
+        for method in simulation.model_method:
+            LOGGER.info(f'ModelMethod type: {type(method).__name__}')
+            if hasattr(method, 'numerical_settings') and method.numerical_settings:
+                LOGGER.info(
+                    f'Found {len(method.numerical_settings)} numerical_settings'
+                )
+                for ns in method.numerical_settings:
+                    LOGGER.info(f'  - {type(ns).__name__}')
+                    if hasattr(ns, 'pseudopotential') and ns.pseudopotential:
+                        LOGGER.info(
+                            f'    Contains {len(ns.pseudopotential)} pseudopotentials'
+                        )
+                        for pp in ns.pseudopotential:
+                            LOGGER.info(f'      * {pp.name}')
+
 
 def test_outcar():
     parser = VASPParser()
     archive = EntryArchive()
     parser.parse('tests/data/vasp/AgAc_relax/OUTCAR', archive, LOGGER)
+
+    # Verify numerical_settings are present
+    simulation = archive.data
+    assert simulation is not None, 'No simulation data in archive'
+    assert simulation.model_method, 'No model_method in simulation'
+
+    method = simulation.model_method[0]
+    assert hasattr(method, 'numerical_settings'), (
+        'ModelMethod missing numerical_settings attribute'
+    )
+    assert method.numerical_settings is not None, 'numerical_settings is None'
+    assert len(method.numerical_settings) > 0, 'numerical_settings is empty'
+
+    LOGGER.info(f'Found {len(method.numerical_settings)} numerical_settings')
+
+    # Check for Pseudopotentials
+    pseudopotentials = [
+        ns for ns in method.numerical_settings if type(ns).__name__ == 'Pseudopotential'
+    ]
+    assert len(pseudopotentials) > 0, 'No Pseudopotential objects in numerical_settings'
+
+    LOGGER.info(f'Found {len(pseudopotentials)} Pseudopotentials:')
+    for pp in pseudopotentials:
+        LOGGER.info(f'  - {pp.name}: {pp.n_valence_electrons} valence electrons')
+        # Verify OUTCAR-specific fields are populated
+        if pp.sha256:
+            LOGGER.info(f'    SHA256: {pp.sha256[:16]}...')
+        if pp.lmax is not None:
+            LOGGER.info(f'    lmax: {pp.lmax}')

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -21,7 +21,9 @@ def test_outcar():
     parser.parse('tests/data/vasp/AgAc_relax/OUTCAR', archive, LOGGER)
 
     simulation = archive.data
+    print(simulation)
     assert simulation is not None, 'No simulation data in archive'
+
     assert simulation.model_method, 'No model_method in simulation'
 
     method = simulation.model_method[0]


### PR DESCRIPTION
## Purpose

Fixes critical global state contamination issue where mapping annotations were being removed, causing parser failures when multiple parsers run in the same process. This affected VASP tests (required subprocess workaround) and could cause production failures in sequential parsing scenarios.

## Scope

**Included**

- Remove `reload()` calls from all 10 parsers
- Remove `remove_mapping_annotations()` calls from Exciting, FHI-aims, and H5MD parsers
- Delete `remove_mapping_annotations()` utility function  
- Revert VASP subprocess isolation workaround to original simple tests
- Clean up unused imports

**Out of scope**

- Fixing other potential global state issues in NOMAD
- Architectural refactoring of mapping parser system

## Context & Links

Related to test isolation issue documented in `VASP_TEST_ISOLATION_FIX.md`. Root cause: mapping annotations stored on class-level `m_def` objects are shared globally. Two antipatterns caused contamination:

1. `reload(schema_module)` creates new class instances, but NOMAD plugin system references original `m_def`
2. `remove_mapping_annotations()` removes annotations from shared global state

Annotations should persist as static metadata for process lifetime, not be dynamically added/removed per parse.

## Reviewer Notes

All parsers now follow VASP's pattern of static annotations. Test carefully that:
- Sequential parsing of different file types works in same process
- Long-running worker processes don't accumulate issues
- No parser-specific cleanup logic was needed for legitimate reasons

## Status

- [x] Ready for review

## Breaking Changes

- [ ] None

## Dependencies / Blockers

- [ ] None

## Testing / Validation

- [x] Unit tests - All 42 parser tests pass in both isolation and full suite
- [x] Manual testing - Verified annotations persist correctly across multiple parses

**Before:** VASP test_outcar failed in full suite, required subprocess isolation
**After:** All tests pass, no workarounds needed