### PR TITLE
Gromacs parse system hierarchy

### DIFF
--- a/src/nomad_simulation_parsers/parsers/gromacs/mdanalysis_parser.py
+++ b/src/nomad_simulation_parsers/parsers/gromacs/mdanalysis_parser.py
@@ -4,6 +4,9 @@ from collections.abc import Callable
 from typing import Any
 
 import MDAnalysis
+import numpy as np
+from ase import Atoms
+from ase.data import chemical_symbols
 from MDAnalysis.topology.tpr import setting as tpr_setting
 from MDAnalysis.topology.tpr import utils as tpr_utils
 
@@ -331,3 +334,280 @@ class GromacsMDAnalysisParser(MDAnalysisParser):
             )
 
         return interactions
+
+    def _parse_element_from_name(self, name: str) -> str:
+        """Extract element symbol from atom name like 'H1', 'CA', etc."""
+        # Try to match 1 or 2 letter element at start of name
+        match = re.match(r'([A-Z][a-z]?)', name)
+        if match:
+            symbol = match.group(1)
+            # Validate it's a real element
+            if symbol in chemical_symbols[1:]:
+                return symbol
+        return 'CGX'  # Fallback for coarse-grained or unknown
+
+    def _generate_chemical_formula(
+        self, particle_indices: np.ndarray, particle_arrays: dict
+    ) -> str:
+        """Generate chemical formula from particle indices using ASE."""
+
+        elements = particle_arrays['elements'][particle_indices]
+        atoms = Atoms(symbols=list(elements))
+        result = atoms.get_chemical_formula(mode='hill')
+        return result
+
+    def _get_particles_info_from_universe(self) -> dict[str, Any]:
+        _atoms = self.universe.atoms
+        particles_elements = np.array(
+            [self._parse_element_from_name(atom.name) for atom in _atoms]
+        )
+        particles_types = np.array([atom.type for atom in _atoms])
+        n_atoms = len(_atoms)
+        moltypes = np.empty(n_atoms, dtype=object)
+        molnums = np.zeros(n_atoms, dtype=int)
+        segments = sorted(set([atom.segid for atom in _atoms]))
+        for seg_idx, segment in enumerate(segments):
+            atom_indices = np.array(
+                [atom.index for atom in _atoms if atom.segid == segment]
+            )
+            n_residues = len(
+                np.unique([atom.resid for atom in _atoms if atom.segid == segment])
+            )
+
+            # Determine molecule type identifier
+            if n_residues == 1:
+                # Single-residue molecule: use residue name
+                moltype = _atoms[atom_indices[0]].resname
+            else:
+                # Multi-residue molecule: use segment ID
+                moltype = segment
+
+            moltypes[atom_indices] = moltype
+            molnums[atom_indices] = seg_idx
+
+        return {
+            'moltypes': moltypes,
+            'molnums': molnums,
+            'resids': np.array([atom.resid for atom in _atoms]),
+            'resnames': np.array([atom.resname for atom in _atoms]),
+            'labels': [atom.name for atom in _atoms],
+            'elements': particles_elements,
+            'types': particles_types,
+        }
+
+    def _create_system_node(
+        self, name: str | int, branch_label: str, particle_indices: np.ndarray, **kwargs
+    ) -> dict[str, Any]:
+        """
+        Create a ModelSystem node with common setup.
+
+        Args:
+            name: System name
+            branch_label: Hierarchy level label
+            particle_indices: Indices of particles in this system
+            **kwargs: Additional attributes: composition_formula, is_representative, ...
+        """
+        system = dict()
+        system['name'] = str(name)
+        system['branch_label'] = branch_label
+        system['particle_indices'] = particle_indices
+        system['is_molecule'] = branch_label == 'molecule'
+
+        # Set any additional attributes
+        for key, value in kwargs.items():
+            system[key] = value
+
+        return system
+
+    def _create_molecule(
+        self, molecule: int, i_molecule: int, particle_arrays: dict
+    ) -> dict[str, Any]:
+        """Create a single molecule with its residues."""
+
+        def _create_residue(
+            res_id: int,
+            restype: str,
+            parent_system: dict[str, Any],
+            particle_arrays: dict,
+        ) -> dict[str, Any]:
+            """Create a single residue."""
+            particle_indices = np.where(particle_arrays['resids'] == res_id)[0]
+            particle_indices = np.intersect1d(
+                particle_indices, parent_system['particle_indices']
+            )
+
+            composition_formula = self._generate_chemical_formula(
+                particle_indices, particle_arrays
+            )
+
+            return self._create_system_node(
+                name=f'{restype}',
+                branch_label='monomer',
+                particle_indices=particle_indices,
+                composition_formula=composition_formula,
+            )
+
+        def _create_monomer_group(
+            restype: str, parent_system: dict[str, Any], particle_arrays: dict[str, Any]
+        ) -> dict[str, Any]:
+            """Create a monomer group with its constituent residues."""
+
+            restype_indices = np.where(particle_arrays['resnames'] == restype)[0]
+            particle_indices = np.intersect1d(
+                restype_indices, parent_system['particle_indices']
+            )
+
+            monomer_group = self._create_system_node(
+                name=f'group_{restype}',
+                branch_label='monomer_group',
+                particle_indices=particle_indices,
+            )
+
+            # Add individual residues
+            restype_resids = np.unique(
+                particle_arrays['resids'][monomer_group['particle_indices']]
+            )
+            for res_id in restype_resids:
+                residue = _create_residue(
+                    res_id, restype, monomer_group, particle_arrays
+                )
+                monomer_group.setdefault('sub_systems', []).append(residue)
+
+            return monomer_group
+
+        def _add_residue_hierarchy(
+            sec_molecule: dict[str, Any], particle_arrays: dict[str, Any]
+        ) -> None:
+            """Add residue/monomer hierarchy to a molecule."""
+            mol_resnames = particle_arrays['resnames'][sec_molecule['particle_indices']]
+            restypes = np.unique(mol_resnames)
+
+            for restype in restypes:
+                sec_monomer_group = _create_monomer_group(
+                    restype, sec_molecule, particle_arrays
+                )
+                sec_molecule.setdefault('sub_systems', []).append(sec_monomer_group)
+
+        particle_indices = np.where(particle_arrays['molnums'] == molecule)[0]
+
+        # Get molecule type from first atom in molecule
+        moltype = particle_arrays['moltypes'][particle_indices[0]]
+        molecule_name = f'{moltype}'
+
+        mol_system = self._create_system_node(
+            name=molecule_name,
+            branch_label='molecule',
+            particle_indices=particle_indices,
+        )
+
+        # Check if molecule has multiple residues
+        mol_resids = np.unique(
+            particle_arrays['resids'][mol_system['particle_indices']]
+        )
+        if len(mol_resids) > 1:
+            _add_residue_hierarchy(mol_system, particle_arrays)
+        else:
+            # Single-residue molecule: add composition formula (terminal branch)
+            mol_system['composition_formula'] = self._generate_chemical_formula(
+                mol_system['particle_indices'], particle_arrays
+            )
+
+        return mol_system
+
+    def parse_molecular_hierarchy(self) -> dict[str, Any]:
+        """
+        Build hierarchical subsystem structure from MDAnalysis universe.
+
+        Creates up to 4 levels based on available topology:
+        - Level 1: molecule_group (molecules of same type grouped)
+        - Level 2: molecule (individual molecular fragment)
+        - Level 3: monomer_group (residues of same type, for polymers)
+        - Level 4: monomer (individual residue)
+
+        Uses MDAnalysis residue information to build hierarchy. Computes composition
+        formulas by counting atom types or residue types at each level.
+
+        Args:
+            source: Source dictionary (unused - we access MDAnalysis directly)
+            **kwargs: Additional keyword arguments from annotation
+
+        Returns:
+            dict: Level-1 subsystems with nested sub_systems
+        """
+
+        mol_hierarchy: dict[str, Any] = {}
+
+        def _get_particles_info() -> dict | None:
+            """Get particle information from the first frame."""
+
+            particles_info = self.get('atoms_info', None)
+
+            if particles_info is None:
+                particles_info = self._get_particles_info_from_universe()
+
+            return particles_info
+
+        def _extract_particle_arrays(particles_info: dict) -> dict:
+            """Extract and process particle information arrays."""
+            particle_labels = particles_info.get('labels', [])
+            n_atoms = len(particle_labels)
+            particles_elements = np.array(
+                particles_info.get('elements', ['CGX'] * n_atoms)
+            )
+            particles_types = np.array(particles_info.get('types', []))
+
+            # Replace CGX placeholder elements if better labels available
+            if 'CGX' in particles_elements:
+                if particle_labels and 'CGX' not in particle_labels:
+                    particles_elements = np.array(particle_labels)
+                else:
+                    particles_elements = particles_types
+
+            return {
+                'moltypes': np.array(particles_info.get('moltypes', [])),
+                'molnums': np.array(particles_info.get('molnums', [])),
+                'resids': np.array(particles_info.get('resids', [])),
+                'resnames': np.array(particles_info.get('resnames', [])),
+                'elements': particles_elements,
+                'types': particles_types,
+            }
+
+        def _create_molecule_group(
+            moltype: str, particle_arrays: dict
+        ) -> dict[str, Any]:
+            """Create a molecule group with its constituent molecules."""
+            particle_indices = np.where(particle_arrays['moltypes'] == moltype)[0]
+
+            # Calculate composition formula
+            mol_nums = particle_arrays['molnums'][particle_indices]
+            moltype_count = np.unique(mol_nums).shape[0]
+
+            molecule_group = self._create_system_node(
+                name=f'group_{moltype}',
+                branch_label='molecule_group',
+                particle_indices=particle_indices,
+                composition_formula=f'{moltype}({moltype_count})',
+            )
+
+            # Add individual molecules
+            molecules = particle_arrays['molnums']
+            for i_molecule, molecule in enumerate(
+                np.unique(molecules[molecule_group['particle_indices']])
+            ):
+                mol = self._create_molecule(molecule, i_molecule, particle_arrays)
+                molecule_group.setdefault('sub_systems', []).append(mol)
+
+            return molecule_group
+
+        particles_info = _get_particles_info()
+        if particles_info is None:
+            return
+        particle_arrays = _extract_particle_arrays(particles_info)
+
+        # Build molecular hierarchy
+        moltypes = np.unique(particle_arrays['moltypes'])
+        for moltype in moltypes:
+            molecule_group = _create_molecule_group(moltype, particle_arrays)
+            mol_hierarchy[moltype] = molecule_group
+
+        return mol_hierarchy

--- a/src/nomad_simulation_parsers/parsers/gromacs/parser.py
+++ b/src/nomad_simulation_parsers/parsers/gromacs/parser.py
@@ -501,6 +501,7 @@ class GromacsMDAnalysisParser(MappingParser):
     _trajectory_steps_sampled: list[int] = []
     _trajectory_steps: list[int] = []
     _thermodynamic_steps: list[int] = []
+    _subsystems_hierarchy: list[dict[str, Any]] = []
 
     # TODO: temporary fix for structlog unable to propagate logger
     @property
@@ -510,8 +511,47 @@ class GromacsMDAnalysisParser(MappingParser):
     def to_dict(self, **kwargs) -> dict[str | int, Any]:
         if self.data_object is not None:
             self.data_object.parse()
-            return self.data_object._results
+            result = self.data_object._results
+
+            # Build complete nested subsystem structure and store as parser attribute
+            # get_subsystems_from_dict will access this to extract system hierarchy
+            self._subsystems_hierarchy = self.get_sub_systems()
+            self.logger.info(
+                'to_dict: Built %d subsystems', len(self._subsystems_hierarchy)
+            )
+
+            return result
         return {}
+
+    def get_subsystems_from_dict(
+        self, source: dict[str, Any], **kwargs
+    ) -> list[dict[str, Any]]:
+        """
+        Extract subsystems from source dict.
+
+        This is called by MappingParser for both top-level and nested ModelSystems.
+        For the root call, returns the full hierarchy from self._subsystems_hierarchy.
+        For nested calls, it extracts 'sub_systems' key from the source dict.
+
+        Args:
+            source: Source dictionary containing subsystem data
+            **kwargs: Additional arguments (unused)
+
+        Returns:
+            List of subsystem dicts from this level
+        """
+
+        # Root call: return the full hierarchy
+        if hasattr(self, '_subsystems_hierarchy') and self._subsystems_hierarchy:
+            # Check if this is the root call by looking at source keys
+            if 'n_atoms' in source and 'sub_systems' not in source:
+                result = self._subsystems_hierarchy
+                return result
+
+        # Nested call: extract from dict's sub_systems key
+        subsystems = source.get('sub_systems', []) if isinstance(source, dict) else []
+
+        return subsystems
 
     def from_dict(self, dct: dict[str, Any]):
         raise NotImplementedError
@@ -569,13 +609,12 @@ class GromacsMDAnalysisParser(MappingParser):
         configurations = []
         for n, _ in enumerate(self._trajectory_steps_sampled):
             config = dict(
+                n_atoms=self.data_object.get_n_atoms(n),
                 labels=self.get_atom_labels(n),
                 positions=self.data_object.get_positions(n),
                 velocities=self.data_object.get_velocities(n),
                 lattice_vectors=self.data_object.get_lattice_vectors(n),
             )
-            # Add topology lists only to first configuration
-            # (topology is time-independent)
             if n == 0:
                 bond_list = self.get_bond_list()
                 if bond_list is not None:
@@ -670,6 +709,15 @@ class GromacsMDAnalysisParser(MappingParser):
             contributions.append(contribution)
 
         return contributions
+
+    def get_sub_systems(
+        self, source: dict[str, Any] = None, **kwargs
+    ) -> list[dict[str, Any]]:
+
+        particles_groups = self.mdanalysis_parser.parse_molecular_hierarchy()
+        source = list(group for group in particles_groups.values())
+
+        return source
 
 
 class GromacsArchiveWriter(MDParser):

--- a/src/nomad_simulation_parsers/schema_packages/gromacs.py
+++ b/src/nomad_simulation_parsers/schema_packages/gromacs.py
@@ -100,18 +100,12 @@ class AtomsState(model_system.AtomsState):
     add_mapping_annotation(model_system.AtomsState.label, TPR_KEY, '.@')
 
 
-class AtomicCell(model_system.Representation):
-    """
-    Map the representation quantities used by GROMACS to the unified
-    Representation fields so annotations and conversion remain correct.
-    """
-
-    add_mapping_annotation(
-        model_system.Representation.lattice_vectors, TPR_KEY, '.lattice_vectors'
-    )
-    add_mapping_annotation(
-        model_system.Representation.periodic_boundary_conditions, LOG_KEY, '.pbc'
-    )
+add_mapping_annotation(
+    model_system.ModelSystem.lattice_vectors, TPR_KEY, '.lattice_vectors'
+)
+add_mapping_annotation(
+    model_system.ModelSystem.periodic_boundary_conditions, LOG_KEY, '.pbc'
+)
 
 
 class ModelSystem(model_system.ModelSystem):
@@ -122,22 +116,39 @@ class ModelSystem(model_system.ModelSystem):
     - positions, velocities: Particle coordinates and velocities
     - bond_list: Bond topology (atom index pairs) extracted from MDAnalysis
     - particle_states (AtomsState): Atom labels and types
-
-    The bond_list is extracted via MDAnalysis.universe.bonds which reads the
-    topology section of the TPR file. This provides connectivity information
-    but does NOT include force field parameters (see ForceField extension
-    roadmap above for details on adding parameter support).
-
-    Angles and dihedrals are extracted via get_force_field_contributions()
-    and stored in ForceField.contributions.
+    - sub_systems: Hierarchical molecular structure (molecule groups → molecules →
+      monomers)
     """
 
+    add_mapping_annotation(model_system.ModelSystem.n_particles, TPR_KEY, '.n_atoms')
     add_mapping_annotation(model_system.ModelSystem.velocities, TPR_KEY, '.velocities')
     add_mapping_annotation(model_system.ModelSystem.positions, TPR_KEY, '.positions')
     add_mapping_annotation(model_system.ModelSystem.bond_list, TPR_KEY, '.bond_list')
+    # sub_systems: recursively extract from nested dicts via function call
+    # Pass '.@' as first argument (current node dict) to function
+    add_mapping_annotation(
+        model_system.ModelSystem.sub_systems,
+        TPR_KEY,
+        ('get_subsystems_from_dict', ['.@']),
+    )
     add_mapping_annotation(model_system.AtomsState.m_def, TPR_KEY, '.labels')
-    add_mapping_annotation(model_system.Representation.m_def, LOG_KEY, '.@')
-    add_mapping_annotation(model_system.Representation.m_def, TPR_KEY, '.@')
+
+
+# ROOT annotation for nested ModelSystem instances
+# When MappingParser creates ModelSystem from subsystems list,
+# use that dict as source root
+add_mapping_annotation(model_system.ModelSystem.m_def, TPR_KEY, '@')
+
+# Subsystem hierarchy annotations (apply to all ModelSystem instances including
+# subsystems)
+add_mapping_annotation(model_system.ModelSystem.name, TPR_KEY, '.name')
+add_mapping_annotation(
+    model_system.ModelSystem.composition_formula, TPR_KEY, '.composition_formula'
+)
+add_mapping_annotation(
+    model_system.ModelSystem.particle_indices, TPR_KEY, '.particle_indices'
+)
+add_mapping_annotation(model_system.ModelSystem.branch_label, TPR_KEY, '.branch_label')
 
 
 class TotalEnergy(outputs.TotalEnergy):

--- a/tests/parsers/test_gromacs_parser.py
+++ b/tests/parsers/test_gromacs_parser.py
@@ -679,3 +679,225 @@ def test_get_compressibility():
     # Test missing
     params = {}
     assert lp.get_compressibility(params) is None
+
+
+def test_system_hierarchy_water():
+    """Test that system hierarchy is parsed from water TPR file."""
+    base = Path(__file__).parent.parent / 'data' / 'gromacs' / 'water'
+    tpr_file = os.path.join(base, 'topol.tpr')
+
+    if not os.path.exists(tpr_file):
+        pytest.skip(f'TPR file not found: {tpr_file}')
+
+    archive = EntryArchive()
+    parser = gromacs_parser.GromacsParser()
+    parser.parse(tpr_file, archive)
+
+    assert archive.data is not None
+    assert len(archive.data.model_system) > 0
+
+    system = archive.data.model_system[0]
+
+    # Water system should have sub_systems (molecule groups)
+    assert system.sub_systems is not None, 'System should have sub_systems hierarchy'
+    assert len(system.sub_systems) > 0, 'Should have at least one molecule group'
+
+    # Check first molecule group (should be SOL for water)
+    mol_group = system.sub_systems[0]
+    assert mol_group.name is not None
+    assert 'group_' in mol_group.name, 'Molecule group should have group_ prefix'
+    assert mol_group.branch_label == 'molecule_group'
+    assert mol_group.composition_formula is not None
+    assert mol_group.particle_indices is not None
+    assert len(mol_group.particle_indices) > 0
+
+    # Molecule group should contain individual molecules
+    assert mol_group.sub_systems is not None
+    assert len(mol_group.sub_systems) > 0, 'Molecule group should contain molecules'
+
+    # Check first molecule
+    molecule = mol_group.sub_systems[0]
+    assert molecule.name is not None
+    assert molecule.branch_label == 'molecule'
+    assert molecule.particle_indices is not None
+    assert len(molecule.particle_indices) > 0
+
+    # Water molecule is terminal (single residue), should have composition_formula
+    assert molecule.composition_formula is not None
+    assert 'H' in molecule.composition_formula
+    assert 'O' in molecule.composition_formula
+
+
+def test_system_hierarchy_polymer():
+    """Test that complex system hierarchy is parsed from protein TPR file."""
+    base = Path(__file__).parent.parent / 'data' / 'gromacs' / 'protein_fsfg'
+    tpr_file = os.path.join(base, 'nvt.tpr')
+
+    if not os.path.exists(tpr_file):
+        pytest.skip(f'TPR file not found: {tpr_file}')
+
+    archive = EntryArchive()
+    parser = gromacs_parser.GromacsParser()
+
+    try:
+        parser.parse(tpr_file, archive)
+    except Exception as e:
+        pytest.skip(f'Could not parse file: {e}')
+
+    assert archive.data is not None
+    assert len(archive.data.model_system) > 0
+
+    system = archive.data.model_system[0]
+
+    # Polymer system should have sub_systems
+    if system.sub_systems is None or len(system.sub_systems) == 0:
+        pytest.skip(
+            'System has no molecular hierarchy (may be coarse-grained or missing bonds)'
+        )
+
+    # Find a molecule group with multi-residue molecules (polymer chain)
+    multi_residue_group = None
+    for mol_group in system.sub_systems:
+        if mol_group.sub_systems and len(mol_group.sub_systems) > 0:
+            first_mol = mol_group.sub_systems[0]
+            # Multi-residue molecule has sub_systems (monomer groups)
+            if first_mol.sub_systems is not None and len(first_mol.sub_systems) > 0:
+                multi_residue_group = mol_group
+                break
+
+    if multi_residue_group is None:
+        pytest.skip(
+            'No multi-residue molecules found (system may only contain single-residue '
+            'molecules)'
+        )
+
+    # Test full 4-level hierarchy: group → molecule → monomer_group → monomer
+    assert multi_residue_group.branch_label == 'molecule_group'
+
+    molecule = multi_residue_group.sub_systems[0]
+    assert molecule.branch_label == 'molecule'
+    assert molecule.sub_systems is not None
+    assert len(molecule.sub_systems) > 0
+
+    # Molecule should contain monomer groups
+    monomer_group = molecule.sub_systems[0]
+    assert monomer_group.branch_label == 'monomer_group'
+    assert 'group_' in monomer_group.name
+    assert monomer_group.sub_systems is not None
+    assert len(monomer_group.sub_systems) > 0
+
+    # Monomer group should contain individual monomers
+    monomer = monomer_group.sub_systems[0]
+    assert monomer.branch_label == 'monomer'
+    assert monomer.composition_formula is not None
+    assert monomer.particle_indices is not None
+    assert len(monomer.particle_indices) > 0
+
+
+def test_system_hierarchy_particle_indices_valid():
+    """Test that particle_indices in hierarchy are valid and consistent."""
+    base = Path(__file__).parent.parent / 'data' / 'gromacs' / 'water'
+    tpr_file = os.path.join(base, 'topol.tpr')
+
+    if not os.path.exists(tpr_file):
+        pytest.skip(f'TPR file not found: {tpr_file}')
+
+    archive = EntryArchive()
+    parser = gromacs_parser.GromacsParser()
+    parser.parse(tpr_file, archive)
+
+    system = archive.data.model_system[0]
+    n_atoms = system.n_particles
+
+    def check_particle_indices(subsystem, parent_indices=None):
+        """Recursively check particle_indices validity."""
+        assert subsystem.particle_indices is not None
+        assert len(subsystem.particle_indices) > 0
+
+        # All indices should be valid (less than n_atoms)
+        assert np.all(subsystem.particle_indices < n_atoms)
+        assert np.all(subsystem.particle_indices >= 0)
+
+        # If parent exists, subsystem indices should be subset of parent
+        if parent_indices is not None:
+            assert np.all(np.isin(subsystem.particle_indices, parent_indices))
+
+        # Recursively check children
+        if subsystem.sub_systems:
+            for child in subsystem.sub_systems:
+                check_particle_indices(child, subsystem.particle_indices)
+
+    # Check all molecule groups
+    for mol_group in system.sub_systems:
+        check_particle_indices(mol_group)
+
+
+def test_system_hierarchy_branch_labels():
+    """Test that branch_label is correctly assigned at each hierarchy level."""
+    base = Path(__file__).parent.parent / 'data' / 'gromacs' / 'protein_fsfg'
+    tpr_file = os.path.join(base, 'nvt.tpr')
+
+    if not os.path.exists(tpr_file):
+        pytest.skip(f'TPR file not found: {tpr_file}')
+
+    archive = EntryArchive()
+    parser = gromacs_parser.GromacsParser()
+
+    try:
+        parser.parse(tpr_file, archive)
+    except Exception as e:
+        pytest.skip(f'Could not parse file: {e}')
+
+    system = archive.data.model_system[0]
+
+    if system.sub_systems is None or len(system.sub_systems) == 0:
+        pytest.skip('System has no molecular hierarchy')
+
+    # Check all levels have correct branch_label
+    for mol_group in system.sub_systems:
+        assert mol_group.branch_label == 'molecule_group'
+
+        if mol_group.sub_systems and len(mol_group.sub_systems) > 0:
+            for molecule in mol_group.sub_systems:
+                assert molecule.branch_label == 'molecule'
+
+                if molecule.sub_systems and len(molecule.sub_systems) > 0:
+                    for monomer_group in molecule.sub_systems:
+                        assert monomer_group.branch_label == 'monomer_group'
+
+                        if (
+                            monomer_group.sub_systems
+                            and len(monomer_group.sub_systems) > 0
+                        ):
+                            for monomer in monomer_group.sub_systems:
+                                assert monomer.branch_label == 'monomer'
+
+
+def test_system_hierarchy_composition_formulas():
+    """Test that composition_formula is assigned to terminal branches."""
+    base = Path(__file__).parent.parent / 'data' / 'gromacs' / 'water'
+    tpr_file = os.path.join(base, 'topol.tpr')
+
+    if not os.path.exists(tpr_file):
+        pytest.skip(f'TPR file not found: {tpr_file}')
+
+    archive = EntryArchive()
+    parser = gromacs_parser.GromacsParser()
+    parser.parse(tpr_file, archive)
+
+    system = archive.data.model_system[0]
+
+    def check_terminal_formulas(subsystem):
+        """Recursively check that terminal branches have composition_formula."""
+        if subsystem.sub_systems is None or len(subsystem.sub_systems) == 0:
+            # Terminal branch should have composition_formula
+            assert subsystem.composition_formula is not None, (
+                f'Terminal {subsystem.branch_label} should have composition_formula'
+            )
+        else:
+            # Non-terminal may or may not have formula, recurse to children
+            for child in subsystem.sub_systems:
+                check_terminal_formulas(child)
+
+    for mol_group in system.sub_systems:
+        check_terminal_formulas(mol_group)


### PR DESCRIPTION
## Purpose 
GROMACS parser didn't extract molecular hierarchy from input files - atoms were stored flat with no molecular/residue organization.

## Scope
- Molecular hierarchy parsing: 4-level structure (molecule groups → molecules → monomer groups → monomers)
- Element extraction: Regex-based parsing from atom names (MDAnalysis doesn't provide .element)
- Molecule detection: Using MDAnalysis residue information
- Composition formulas: ASE-generated Hill notation for terminal branches
- MappingParser integration:
  - Recursive extraction via _subsystems_hierarchy parser attribute
  - Schema annotations: ModelSystem.sub_systems, .composition_formula, .particle_indices, .branch_label
- Tests: 5 new tests validating hierarchy structure, particle indices, branch labels, and composition formulas

## Status 
- [ ] Draft / In progress (not ready for full review)
- [x] Ready for review
- [ ] Blocked (explain below)

## Dependencies / Blockers 
- [x] None.
- [ ] Related PRs:
- [ ] Open design questions:
- [ ] External dependencies (people, decisions, data, releases):

## Testing / Validation 
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual testing (brief description):
- [ ] Not applicable (explain why):
 
## Reviewer Notes 
The tests will be extended/updated. 

