### PR TITLE
Hotfix: Comment out removed convergence tolerance field mappings

### DIFF
--- a/src/nomad_simulation_parsers/schema_packages/abinit.py
+++ b/src/nomad_simulation_parsers/schema_packages/abinit.py
@@ -23,18 +23,19 @@ class GeometryOptimizationMethod(
         OUT_KEY,
         ('get_workflow_method', []),
     )
-    add_mapping_annotation(
-        workflow.geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_energy_difference,
-        OUT_KEY,
-        ('get_input_var', [], dict(name='tolmxde', n_dataset=1, default=0.0)),
-        unit='hartree',
-    )
-    add_mapping_annotation(
-        workflow.geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_force_maximum,
-        OUT_KEY,
-        ('get_input_var', [], dict(name='tolmxf', n_dataset=1, default=0.0)),
-        unit='hartree/bohr',
-    )
+    # TODO: Re-enable when nomad-simulations#260 is merged
+    # add_mapping_annotation(
+    #     workflow.geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_energy_difference,
+    #     OUT_KEY,
+    #     ('get_input_var', [], dict(name='tolmxde', n_dataset=1, default=0.0)),
+    #     unit='hartree',
+    # )
+    # add_mapping_annotation(
+    #     workflow.geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_force_maximum,
+    #     OUT_KEY,
+    #     ('get_input_var', [], dict(name='tolmxf', n_dataset=1, default=0.0)),
+    #     unit='hartree/bohr',
+    # )
 
 
 add_mapping_annotation(

--- a/src/nomad_simulation_parsers/schema_packages/abinit.py
+++ b/src/nomad_simulation_parsers/schema_packages/abinit.py
@@ -25,13 +25,15 @@ class GeometryOptimizationMethod(
     )
     # TODO: Re-enable when nomad-simulations#260 is merged
     # add_mapping_annotation(
-    #     workflow.geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_energy_difference,
+    #     workflow.geometry_optimization.GeometryOptimizationMethod
+    #         .convergence_tolerance_energy_difference,
     #     OUT_KEY,
     #     ('get_input_var', [], dict(name='tolmxde', n_dataset=1, default=0.0)),
     #     unit='hartree',
     # )
     # add_mapping_annotation(
-    #     workflow.geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_force_maximum,
+    #     workflow.geometry_optimization.GeometryOptimizationMethod
+    #         .convergence_tolerance_force_maximum,
     #     OUT_KEY,
     #     ('get_input_var', [], dict(name='tolmxf', n_dataset=1, default=0.0)),
     #     unit='hartree/bohr',

--- a/src/nomad_simulation_parsers/schema_packages/gromacs.py
+++ b/src/nomad_simulation_parsers/schema_packages/gromacs.py
@@ -203,12 +203,13 @@ class GeometryOptimizationModel(geometry_optimization.GeometryOptimization):
         LOG_KEY,
         '.input_parameters.nsteps',
     )
-    add_mapping_annotation(
-        geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_force_maximum,
-        LOG_KEY,
-        '.input_parameters.emtol',
-        unit='kilojoule/avogadro_number/nanometer',
-    )
+    # TODO: Re-enable when nomad-simulations#260 is merged
+    # add_mapping_annotation(
+    #     geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_force_maximum,
+    #     LOG_KEY,
+    #     '.input_parameters.emtol',
+    #     unit='kilojoule/avogadro_number/nanometer',
+    # )
 
 
 class GeometryOptimizationResults(geometry_optimization.GeometryOptimizationResults):

--- a/src/nomad_simulation_parsers/schema_packages/gromacs.py
+++ b/src/nomad_simulation_parsers/schema_packages/gromacs.py
@@ -205,7 +205,8 @@ class GeometryOptimizationModel(geometry_optimization.GeometryOptimization):
     )
     # TODO: Re-enable when nomad-simulations#260 is merged
     # add_mapping_annotation(
-    #     geometry_optimization.GeometryOptimizationMethod.convergence_tolerance_force_maximum,
+    #     geometry_optimization.GeometryOptimizationMethod
+    #         .convergence_tolerance_force_maximum,
     #     LOG_KEY,
     #     '.input_parameters.emtol',
     #     unit='kilojoule/avogadro_number/nanometer',


### PR DESCRIPTION
## Purpose
Fix parser loading failures caused by references to removed convergence tolerance fields in the schema.

## Scope

**Included**
- Comment out mappings to deleted `convergence_tolerance_*` fields in abinit and gromacs parsers
- Ruff formatting compliance fixes

**Out of scope**
- Migration to new `WorkflowConvergenceTarget` API (will be handled separately)

## Context & Links

PR nomad-simulations#260 removed `convergence_tolerance_energy_difference` and `convergence_tolerance_force_maximum` fields from `GeometryOptimizationMethod` (merged March 19, 2026), replacing them with `WorkflowConvergenceTarget` subsections.

PR #151 was written against the old API but merged March 23 after the schema change, causing AttributeError during parser loading.

## Reviewer Notes

This is a temporary hotfix to restore parser functionality. Migration to the new `WorkflowConvergenceTarget` API will be handled separately.

## Status

- [x] Ready for review

## Breaking Changes

- [ ] None

## Dependencies / Blockers

- [ ] None

## Testing / Validation

- [x] All 49 tests pass (1 abinit, 48 gromacs)
- [x] Ruff checks pass