### PR TITLE
Workaround for recursive workflow tasks in H5MD parser

### DIFF
--- a/src/nomad_simulation_parsers/schema_packages/h5md.py
+++ b/src/nomad_simulation_parsers/schema_packages/h5md.py
@@ -1297,18 +1297,18 @@ MolecularDynamicsResults.free_energy_calculations.m_annotations.setdefault(
 
 # Use our custom MolecularDynamics class with custom results
 # TODO: Permanently fix workflow recursion bug!
-# MolecularDynamics (via `SimulationWorkflow` -> `SimulationTask` -> `Task`) is itself a
-# `Task` subclass. Its `m_def` carries the HDF5_KEY annotation.
-# When the MappingParser processes the `Workflow.tasks` `SubSection` with that key,
+# `MolecularDynamics` (via `SimulationWorkflow` -> `SimulationTask` -> `Task`) is itself
+# a `Task` subclass. Its `m_def` carries the `HDF5_KEY` annotation.
+# When the `MappingParser` processes the `Workflow.tasks` `SubSection` with that key,
 # the third lookup level in `nomad.parsing.file_parser.build_section_mapper` searches
 # for all `Task` inheritors that have the same annotation, finds `MolecularDynamics`
-# itself or `GeometryOptimization`, and instantiates it as a child task, which then
-# repeats the same search, in the worst case causing infinite nesting.
+# itself, and instantiates it as a child task, which then repeats the same search, in
+# the worst case causing infinite nesting.
 #
 # The current workaround adds a first lookup level annotation directly on
 # `SimulationWorkflow.tasks` pointing to `.tasks` (an empty/nonexistent path in the
-# source), which blocks level 3 from ever running for that `SubSection`. The sections
-# will be filled by workflow normalizer from `outputs`.
+# source), which blocks level 3 from ever running for that `SubSection`. The SubSections
+# will be filled by the workflow normalizer from `outputs`.
 add_mapping_annotation(workflow_general.SimulationWorkflow.tasks, HDF5_KEY, '.tasks')
 add_mapping_annotation(MolecularDynamics.m_def, HDF5_KEY, '@')
 add_mapping_annotation(MolecularDynamics.method, HDF5_KEY, '@')

--- a/src/nomad_simulation_parsers/schema_packages/h5md.py
+++ b/src/nomad_simulation_parsers/schema_packages/h5md.py
@@ -30,6 +30,7 @@ from nomad_simulations.schema_packages import (
 )
 
 # from simulationworkflowschema import molecular_dynamics
+from nomad_simulations.schema_packages.workflow import general as workflow_general
 from nomad_simulations.schema_packages.workflow import molecular_dynamics, trajectory
 
 from nomad_simulation_parsers.schema_packages.utils import add_mapping_annotation
@@ -622,7 +623,7 @@ add_mapping_annotation(
 )
 
 
-## class BarostatParameters(molecular_dynamics.BarostatParameters):
+## class BarostatParameters(molecular_dynamics.BarostatParameters):f
 
 
 h5md_path_barostat = f'{h5md_path_md}.barostat_parameters'
@@ -1295,10 +1296,22 @@ MolecularDynamicsResults.free_energy_calculations.m_annotations.setdefault(
 
 
 # Use our custom MolecularDynamics class with custom results
+# TODO: Permanently fix workflow recursion bug!
+# MolecularDynamics (via `SimulationWorkflow` -> `SimulationTask` -> `Task`) is itself a
+# `Task` subclass. Its `m_def` carries the HDF5_KEY annotation.
+# When the MappingParser processes the `Workflow.tasks` `SubSection` with that key,
+# the third lookup level in `nomad.parsing.file_parser.build_section_mapper` searches
+# for all `Task` inheritors that have the same annotation, finds `MolecularDynamics`
+# itself or `GeometryOptimization`, and instantiates it as a child task, which then
+# repeats the same search, in the worst case causing infinite nesting.
+#
+# The current workaround adds a first lookup level annotation directly on
+# `SimulationWorkflow.tasks` pointing to `.tasks` (an empty/nonexistent path in the
+# source), which blocks level 3 from ever running for that `SubSection`. The sections
+# will be filled by workflow normalizer from `outputs`.
+add_mapping_annotation(workflow_general.SimulationWorkflow.tasks, HDF5_KEY, '.tasks')
 add_mapping_annotation(MolecularDynamics.m_def, HDF5_KEY, '@')
-
 add_mapping_annotation(MolecularDynamics.method, HDF5_KEY, '@')
-
 add_mapping_annotation(MolecularDynamics.results, HDF5_KEY, '@')
 
 add_mapping_annotation(molecular_dynamics.MolecularDynamics.outputs, HDF5_KEY, '@')

--- a/src/nomad_simulation_parsers/schema_packages/h5md.py
+++ b/src/nomad_simulation_parsers/schema_packages/h5md.py
@@ -623,7 +623,7 @@ add_mapping_annotation(
 )
 
 
-## class BarostatParameters(molecular_dynamics.BarostatParameters):f
+## class BarostatParameters(molecular_dynamics.BarostatParameters):
 
 
 h5md_path_barostat = f'{h5md_path_md}.barostat_parameters'

--- a/tests/parsers/test_h5md_parser.py
+++ b/tests/parsers/test_h5md_parser.py
@@ -368,6 +368,7 @@ def assert_workflow(archive: EntryArchive) -> None:
     sec_workflow = archive.workflow2
     sec_workflow_results = sec_workflow.results
 
+    # TODO: Adjust after permanent recursion bug fix.
     # Regression: after normalization tasks must be shallow (no nested tasks).
     # Recursive parsing would produce MolecularDynamics nested inside each task.
     for task in sec_workflow.tasks:

--- a/tests/parsers/test_h5md_parser.py
+++ b/tests/parsers/test_h5md_parser.py
@@ -368,6 +368,13 @@ def assert_workflow(archive: EntryArchive) -> None:
     sec_workflow = archive.workflow2
     sec_workflow_results = sec_workflow.results
 
+    # Regression: after normalization tasks must be shallow (no nested tasks).
+    # Recursive parsing would produce MolecularDynamics nested inside each task.
+    for task in sec_workflow.tasks:
+        assert not any(
+            hasattr(inp, 'tasks') and inp.tasks for inp in (task.inputs or [])
+        )
+
     assert_md_method(sec_workflow)
     assert_thermostats_barostats_shear(sec_workflow)
     assert_radial_distribution_functions(sec_workflow_results)
@@ -384,6 +391,9 @@ def test_md(parser):
         archive,
         None,
     )
+    # Regression: parser must not populate tasks (would cause infinite recursion).
+    # Tasks are filled post-parse by the workflow normalizer from outputs.
+    assert archive.workflow2.tasks == []
     normalize_all(archive, logger=logger)
 
     assert_h5md_header(archive)


### PR DESCRIPTION
## Purpose

`MolecularDynamics` (via `SimulationWorkflow` -> `SimulationTask` -> `Task`) is itself a `Task` subclass. Its `m_def` carries the `HDF5_KEY` annotation. 
When the `MappingParser` processes the `Workflow.tasks` `SubSection` with that key, the third lookup level in `nomad.parsing.file_parser.build_section_mapper` searches for all `Task` inheritors that have the same annotation, finds `MolecularDynamics` itself, and instantiates it as a child task, which then repeats the same search, in the worst case causing infinite nesting.

## Scope

Adds a first lookup level annotation directly on `SimulationWorkflow.tasks` pointing to `.tasks` (an empty/nonexistent path in the source), which blocks lookup level 3 (e.g., `MolecularDynamics`) from ever running for that `SubSection`. The SubSections will be appropriately filled by the workflow normalizer from `outputs`.

**Out of scope**

Permanent fix for the recursion bug.

## Context & Links

- Closes #163

## Reviewer Notes

This is a workaround, not a permanent fix.

## Status

- [X] Ready for review

## Breaking Changes

- [X] None

## Dependencies / Blockers

- [X] Open design questions (explain): The underlying bug will need a premanent fix.

## Testing / Validation

- [X] Unit tests
- [X] Manual testing (explain): Visually confirmed that `MolecularDynamics` recursion is gone from generated archive.