### PR TITLE
Resolved field naming conflict (values -> lambda_values)

### DIFF
--- a/src/nomad_simulation_parsers/schema_packages/h5md.py
+++ b/src/nomad_simulation_parsers/schema_packages/h5md.py
@@ -928,7 +928,7 @@ add_mapping_annotation(
 )
 
 add_mapping_annotation(
-    molecular_dynamics.Lambdas.coupling_parameters,
+    molecular_dynamics.Lambdas.lambda_values,
     HDF5_KEY,
     (
         'map_value',

--- a/src/nomad_simulation_parsers/schema_packages/h5md.py
+++ b/src/nomad_simulation_parsers/schema_packages/h5md.py
@@ -928,7 +928,7 @@ add_mapping_annotation(
 )
 
 add_mapping_annotation(
-    molecular_dynamics.Lambdas.values,
+    molecular_dynamics.Lambdas.coupling_parameters,
     HDF5_KEY,
     (
         'map_value',


### PR DESCRIPTION
Python's attribute lookup checks `instance.__dict__` before the class hierarchy.
Once the lambda grid array was stored under the key 'values', any access to
`instance.values` resolved to a numpy array rather than the inherited
`MSection.values()` method.

`MetainfoParser.from_dict` uses `sub_section.values()` as an emptiness check
after populating each subsection:
```
# nomad/parsing/file_parser/mapping_parser.py
if not [
    v
    for v in sub_section.values()   # resolves to numpy array, not method
    if (isinstance(v, list | np.ndarray) and len(v)) or v
]:
    root.m_remove_sub_section(section, index=n)
```
With the `values` quantity set, this called the stored numpy array as a function
-> `TypeError: 'numpy.ndarray' object is not callable`, crashing the parser on parsing
any FEP run.

## Fix:
The `Lambdas.values` quantity was renamed to `Lambdas.lambda_values`.
This eliminates the collision without requiring changes to `nomad-FAIR`.
All references were updated accordingly.