### PR TITLE
Add KMesh support for FHI-aims parser

### DIFF
--- a/src/nomad_simulation_parsers/parsers/fhiaims/common.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/common.py
@@ -83,6 +83,14 @@ class ControlParser(TextParser):
             else:
                 return np.reshape(val, (3, 3))
 
+        def str_to_int_array(val_in: str) -> np.ndarray:
+            """Parse space-separated integers into numpy array."""
+            return np.array([int(v) for v in val_in.strip().split()], dtype=np.int32)
+
+        def str_to_float_array(val_in: str) -> np.ndarray:
+            """Parse space-separated floats into numpy array."""
+            return np.array([float(v) for v in val_in.strip().split()], dtype=np.float64)
+
         self._quantities = [
             Quantity(
                 'displacement', r'\n *phonon\s*displacement\s*([\d\.]+)', dtype=float
@@ -99,4 +107,16 @@ class ControlParser(TextParser):
                 str_operation=str_to_supercell,
             ),
             Quantity('nac', r'\n *phonon nac\s*(.+)', str_operation=str_to_nac),
+            Quantity(
+                'k_grid',
+                r'\n *k_grid\s*([\d ]+)',
+                str_operation=str_to_int_array,
+                convert=False,
+            ),
+            Quantity(
+                'k_offset',
+                r'\n *k_offset\s*([-+\d\. ]+)',
+                str_operation=str_to_float_array,
+                convert=False,
+            ),
         ]

--- a/src/nomad_simulation_parsers/parsers/fhiaims/common.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/common.py
@@ -89,7 +89,9 @@ class ControlParser(TextParser):
 
         def str_to_float_array(val_in: str) -> np.ndarray:
             """Parse space-separated floats into numpy array."""
-            return np.array([float(v) for v in val_in.strip().split()], dtype=np.float64)
+            return np.array(
+                [float(v) for v in val_in.strip().split()], dtype=np.float64
+            )
 
         self._quantities = [
             Quantity(

--- a/src/nomad_simulation_parsers/parsers/fhiaims/common.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/common.py
@@ -89,9 +89,6 @@ class ControlParser(TextParser):
             converter = int if dtype == np.int32 else float
             return np.array([converter(v) for v in val_in.strip().split()], dtype=dtype)
 
-        str_to_int_array = partial(str_to_array, dtype=np.int32)
-        str_to_float_array = partial(str_to_array, dtype=np.float64)
-
         self._quantities = [
             Quantity(
                 'displacement', r'\n *phonon\s*displacement\s*([\d\.]+)', dtype=float
@@ -111,13 +108,13 @@ class ControlParser(TextParser):
             Quantity(
                 'k_grid',
                 r'\n *k_grid\s*([\d ]+)',
-                str_operation=str_to_int_array,
+                str_operation=partial(str_to_array, dtype=np.int32),
                 convert=False,
             ),
             Quantity(
                 'k_offset',
                 r'\n *k_offset\s*([-+\d\. ]+)',
-                str_operation=str_to_float_array,
+                str_operation=partial(str_to_array, dtype=np.float64),
                 convert=False,
             ),
         ]

--- a/src/nomad_simulation_parsers/parsers/fhiaims/common.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/common.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Any
 
 import numpy as np
@@ -84,11 +83,6 @@ class ControlParser(TextParser):
             else:
                 return np.reshape(val, (3, 3))
 
-        def str_to_array(val_in: str, dtype) -> np.ndarray:
-            """Parse space-separated values into numpy array."""
-            converter = int if dtype == np.int32 else float
-            return np.array([converter(v) for v in val_in.strip().split()], dtype=dtype)
-
         self._quantities = [
             Quantity(
                 'displacement', r'\n *phonon\s*displacement\s*([\d\.]+)', dtype=float
@@ -105,16 +99,6 @@ class ControlParser(TextParser):
                 str_operation=str_to_supercell,
             ),
             Quantity('nac', r'\n *phonon nac\s*(.+)', str_operation=str_to_nac),
-            Quantity(
-                'k_grid',
-                r'\n *k_grid\s*([\d ]+)',
-                str_operation=partial(str_to_array, dtype=np.int32),
-                convert=False,
-            ),
-            Quantity(
-                'k_offset',
-                r'\n *k_offset\s*([-+\d\. ]+)',
-                str_operation=partial(str_to_array, dtype=np.float64),
-                convert=False,
-            ),
+            Quantity('k_grid', r'\n *k_grid\s*([\d ]+)', dtype=np.int32),
+            Quantity('k_offset', r'\n *k_offset\s*([-+\d\. ]+)', dtype=np.float64),
         ]

--- a/src/nomad_simulation_parsers/parsers/fhiaims/common.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/common.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -83,15 +84,13 @@ class ControlParser(TextParser):
             else:
                 return np.reshape(val, (3, 3))
 
-        def str_to_int_array(val_in: str) -> np.ndarray:
-            """Parse space-separated integers into numpy array."""
-            return np.array([int(v) for v in val_in.strip().split()], dtype=np.int32)
+        def str_to_array(val_in: str, dtype) -> np.ndarray:
+            """Parse space-separated values into numpy array."""
+            converter = int if dtype == np.int32 else float
+            return np.array([converter(v) for v in val_in.strip().split()], dtype=dtype)
 
-        def str_to_float_array(val_in: str) -> np.ndarray:
-            """Parse space-separated floats into numpy array."""
-            return np.array(
-                [float(v) for v in val_in.strip().split()], dtype=np.float64
-            )
+        str_to_int_array = partial(str_to_array, dtype=np.int32)
+        str_to_float_array = partial(str_to_array, dtype=np.float64)
 
         self._quantities = [
             Quantity(

--- a/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
@@ -744,8 +744,9 @@ class FHIAimsOutFileParser(TextParser):
             ),  # taken from tests/data/fhi_aims
             Quantity(
                 'k_offset',
-                rf'{RE_N} *k_offset\s*([-+\d\. ]+)',
+                rf'{RE_N} *k_offset\s*([-+\d\.Ee ]+)',
                 repeats=False,
+                str_operation=lambda value: np.fromstring(value, sep=' '),
             ),
             Quantity(
                 'controlInOut_MD_time_step',

--- a/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
@@ -743,6 +743,11 @@ class FHIAimsOutFileParser(TextParser):
                 'k_grid', rf'{RE_N} *Found k-point grid:\s*([\d ]+)', repeats=False
             ),  # taken from tests/data/fhi_aims
             Quantity(
+                'k_offset',
+                rf'{RE_N} *k_offset\s*([-+\d\. ]+)',
+                repeats=False,
+            ),
+            Quantity(
                 'controlInOut_MD_time_step',
                 rf'{RE_N} *Molecular dynamics time step\s*=\s*([\d\.]+)\s*'
                 rf'(?P<__unit>[\w]+)',

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -308,6 +308,17 @@ class FHIAimsOutMappingParser(TextMappingParser):
     def get_gw_flag(self, gw_flag: str):
         return self._gw_flag_map.get(gw_flag)
 
+    def get_k_offset_with_default(self, k_offset):
+        """
+        Return k_offset or FHI-aims default [0,0,0] (Gamma-centered).
+
+        FHI-aims uses Gamma-centered grids by default when k_offset
+        is not specified in control.in.
+        """
+        if k_offset is None:
+            return np.array([0.0, 0.0, 0.0])
+        return k_offset
+
     def get_scf_steps(self, source: dict[str, Any]) -> dict[str, Any]:
         scf_iterations = source.get('self_consistency', [])
         if not scf_iterations:

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -494,11 +494,31 @@ class FHIAimsArchiveWriter(ArchiveWriter):
 
         archive_handler = FHIAimsMetainfoParser()
         archive_handler.annotation_key = self.annotation_key
+
+        # Create Simulation without manual DFT - let annotations create it
         self.archive.data = Simulation(program=Program(name='FHI-aims'))
 
         archive_handler.data_object = self.archive.data
 
         out_parser.convert(archive_handler, remove=False)
+
+        # Manually create and populate DFT section since annotations don't work
+        # This is a workaround until the mapping framework issue is resolved
+        from nomad_simulations.schema_packages.model_method import DFT
+        from nomad_simulations.schema_packages.numerical_settings import KMesh
+
+        dft = DFT()
+
+        # Populate k-mesh if present in parsed data
+        # KMesh is a type of NumericalSettings, so add it directly
+        if 'k_grid' in out_parser.data:
+            k_mesh = KMesh(grid=out_parser.data['k_grid'])
+            if 'k_offset' in out_parser.data:
+                k_mesh.offset = out_parser.data['k_offset']
+
+            dft.numerical_settings = [k_mesh]
+
+        self.archive.data.model_method = [dft]
 
         # separate parsing of dos due to a problem with mapping physical
         # property variables

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -495,30 +495,10 @@ class FHIAimsArchiveWriter(ArchiveWriter):
         archive_handler = FHIAimsMetainfoParser()
         archive_handler.annotation_key = self.annotation_key
 
-        # Create Simulation without manual DFT - let annotations create it
         self.archive.data = Simulation(program=Program(name='FHI-aims'))
-
         archive_handler.data_object = self.archive.data
 
         out_parser.convert(archive_handler, remove=False)
-
-        # Manually create and populate DFT section since annotations don't work
-        # This is a workaround until the mapping framework issue is resolved
-        from nomad_simulations.schema_packages.model_method import DFT
-        from nomad_simulations.schema_packages.numerical_settings import KMesh
-
-        dft = DFT()
-
-        # Populate k-mesh if present in parsed data
-        # KMesh is a type of NumericalSettings, so add it directly
-        if 'k_grid' in out_parser.data:
-            k_mesh = KMesh(grid=out_parser.data['k_grid'])
-            if 'k_offset' in out_parser.data:
-                k_mesh.offset = out_parser.data['k_offset']
-
-            dft.numerical_settings = [k_mesh]
-
-        self.archive.data.model_method = [dft]
 
         # separate parsing of dos due to a problem with mapping physical
         # property variables

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -308,7 +308,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
     def get_gw_flag(self, gw_flag: str):
         return self._gw_flag_map.get(gw_flag)
 
-    def get_k_offset_with_default(self, k_offset):
+    def get_k_offset_with_default(self, k_offset: np.ndarray | None) -> np.ndarray:
         """
         Return k_offset or FHI-aims default [0,0,0] (Gamma-centered).
 

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -292,7 +292,11 @@ class KSpace(numerical_settings.KSpace):
 
 class KMesh(numerical_settings.KMesh):
     add_mapping_annotation(numerical_settings.KMesh.grid, TEXT_KEY, '.k_grid')
-    add_mapping_annotation(numerical_settings.KMesh.offset, TEXT_KEY, '.k_offset')
+    add_mapping_annotation(
+        numerical_settings.KMesh.offset,
+        TEXT_KEY,
+        ('get_k_offset_with_default', ['.k_offset']),
+    )
 
 
 try:

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -50,7 +50,7 @@ class Simulation(general.Simulation):
             dict(include=['lattice_vectors', 'structure', 'sub_structure']),
         ),
     )
-    # DFT method
+    # DFT method - only annotate DFT.m_def, not ModelMethod base class
     add_mapping_annotation(model_method.DFT.m_def, TEXT_KEY, '.@')
     # gw method
     add_mapping_annotation(model_method.GW.m_def, TEXT_GW_KEY, '.@')

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -10,6 +10,7 @@ from nomad_simulations.schema_packages import (
     general,
     model_method,
     model_system,
+    numerical_settings,
     outputs,
     properties,
     workflow,
@@ -84,6 +85,12 @@ class Simulation(general.Simulation):
 
 class Program(general.Program):
     add_mapping_annotation(general.Program.version, TEXT_KEY, '.version')
+
+
+class DFT(model_method.DFT):
+    add_mapping_annotation(
+        model_method.DFT.numerical_settings, TEXT_KEY, '.@'
+    )
 
 
 # class DFT(model_method.DFT):
@@ -279,6 +286,21 @@ class GeometryOptimizationMethod(
     workflow.geometry_optimization.GeometryOptimizationMethod.optimization_method.m_annotations.setdefault(
         MAPPING_ANNOTATION_KEY, {}
     ).update(dict(geo_opt_workflow=Mapper(mapper='.geometry_relaxation_method')))
+
+
+class NumericalSettings(numerical_settings.NumericalSettings):
+    add_mapping_annotation(
+        numerical_settings.KMesh.m_def, TEXT_KEY, '.@'
+    )
+
+
+class KMesh(numerical_settings.KMesh):
+    add_mapping_annotation(
+        numerical_settings.KMesh.grid, TEXT_KEY, '.k_grid'
+    )
+    add_mapping_annotation(
+        numerical_settings.KMesh.offset, TEXT_KEY, '.k_offset'
+    )
 
 
 try:

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -88,9 +88,7 @@ class Program(general.Program):
 
 
 class DFT(model_method.DFT):
-    add_mapping_annotation(
-        model_method.DFT.numerical_settings, TEXT_KEY, '.@'
-    )
+    add_mapping_annotation(numerical_settings.KSpace.m_def, TEXT_KEY, '.@')
 
 
 # class DFT(model_method.DFT):
@@ -288,19 +286,13 @@ class GeometryOptimizationMethod(
     ).update(dict(geo_opt_workflow=Mapper(mapper='.geometry_relaxation_method')))
 
 
-class NumericalSettings(numerical_settings.NumericalSettings):
-    add_mapping_annotation(
-        numerical_settings.KMesh.m_def, TEXT_KEY, '.@'
-    )
+class KSpace(numerical_settings.KSpace):
+    add_mapping_annotation(numerical_settings.KSpace.k_mesh, TEXT_KEY, '.@')
 
 
 class KMesh(numerical_settings.KMesh):
-    add_mapping_annotation(
-        numerical_settings.KMesh.grid, TEXT_KEY, '.k_grid'
-    )
-    add_mapping_annotation(
-        numerical_settings.KMesh.offset, TEXT_KEY, '.k_offset'
-    )
+    add_mapping_annotation(numerical_settings.KMesh.grid, TEXT_KEY, '.k_grid')
+    add_mapping_annotation(numerical_settings.KMesh.offset, TEXT_KEY, '.k_offset')
 
 
 try:

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -1,6 +1,6 @@
 from nomad.datamodel import EntryArchive
 from nomad.utils import get_logger
-from pytest import approx
+from pytest import approx, mark
 
 from nomad_simulation_parsers.parsers.fhiaims.parser import FHIAimsParser
 
@@ -67,55 +67,33 @@ def test_scf_steps_quantities():
     )
 
 
-def test_k_mesh():
-    parser = FHIAimsParser()
-    archive = EntryArchive()
-    parser.parse('tests/data/fhiaims/Si_geomopt/out.out', archive, LOGGER)
-
-    # Check DFT section exists
-    assert archive.data.model_method is not None
-    assert len(archive.data.model_method) == 1
-    dft = archive.data.model_method[0]
-    assert dft.m_def.name == 'DFT'
-
-    # Check NumericalSettings/KSpace exists
-    assert dft.numerical_settings is not None
-    assert len(dft.numerical_settings) == 1
-    k_space = dft.numerical_settings[0]
-    assert k_space.m_def.name == 'KSpace'
-
-    # Check KSpace.k_mesh exists
-    assert k_space.k_mesh is not None
-    assert len(k_space.k_mesh) == 1
-    k_mesh = k_space.k_mesh[0]
-    assert k_mesh.m_def.name == 'KMesh'
-
-    # Check k-grid values
-    assert k_mesh.grid is not None
-    assert list(k_mesh.grid) == [8, 8, 8]
-
-    # Check k_offset default (FHI-aims uses Gamma-centered by default)
-    assert k_mesh.offset is not None
-    assert list(k_mesh.offset) == approx([0.0, 0.0, 0.0])
-
-
-def test_k_mesh_with_offset(tmp_path):
-    """Test k-mesh parsing when k_offset is present."""
+@mark.parametrize(
+    'k_offset_line,expected_offset',
+    [
+        (None, [0.0, 0.0, 0.0]),
+        ('  k_offset                           0.5 0.25 0.0\n', [0.5, 0.25, 0.0]),
+    ],
+    ids=['default_offset', 'explicit_offset'],
+)
+def test_k_mesh(tmp_path, k_offset_line, expected_offset):
+    """Test k-mesh parsing with and without explicit k_offset."""
     source_path = 'tests/data/fhiaims/Si_geomopt/out.out'
-    with open(source_path, encoding='utf-8') as f:
-        content = f.read()
 
-    # Inject k_offset line after k_grid
-    modified_content = content.replace(
-        '  Found k-point grid:         8         8         8\n',
-        '  Found k-point grid:         8         8         8\n'
-        '  k_offset                           0.5 0.25 0.0\n',
-        1,
-    )
-    assert modified_content != content, 'Failed to inject k_offset line'
-
-    test_file = tmp_path / 'out_with_k_offset.out'
-    test_file.write_text(modified_content, encoding='utf-8')
+    if k_offset_line is None:
+        # Use original file (no k_offset)
+        test_file = source_path
+    else:
+        # Inject k_offset line after k_grid
+        with open(source_path, encoding='utf-8') as f:
+            content = f.read()
+        modified_content = content.replace(
+            '  Found k-point grid:         8         8         8\n',
+            '  Found k-point grid:         8         8         8\n' + k_offset_line,
+            1,
+        )
+        assert modified_content != content, 'Failed to inject k_offset line'
+        test_file = tmp_path / 'out_with_k_offset.out'
+        test_file.write_text(modified_content, encoding='utf-8')
 
     parser = FHIAimsParser()
     archive = EntryArchive()
@@ -143,6 +121,6 @@ def test_k_mesh_with_offset(tmp_path):
     assert k_mesh.grid is not None
     assert list(k_mesh.grid) == [8, 8, 8]
 
-    # Check k_offset values
+    # Check k_offset values (default or explicit)
     assert k_mesh.offset is not None
-    assert list(k_mesh.offset) == approx([0.5, 0.25, 0.0])
+    assert list(k_mesh.offset) == approx(expected_offset)

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -65,3 +65,18 @@ def test_scf_steps_quantities():
     assert first_steps.delta_density_rms[-1].to('coulomb').magnitude == approx(
         6.375e-08 * 1.602176634e-19
     )
+
+
+def test_k_mesh():
+    parser = FHIAimsParser()
+    archive = EntryArchive()
+    parser.parse('tests/data/fhiaims/Si_geomopt/out.out', archive, LOGGER)
+
+    # Debug: print archive structure
+    print(f"archive.data: {archive.data}")
+    print(f"model_method: {archive.data.model_method if archive.data else None}")
+
+    # For now, skip the test as model_method is not populated
+    # This needs investigation - possibly the DFT method is created elsewhere
+    # or requires normalization
+    pass

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -78,10 +78,16 @@ def test_k_mesh():
     dft = archive.data.model_method[0]
     assert dft.m_def.name == 'DFT'
 
-    # Check NumericalSettings/KMesh exists
+    # Check NumericalSettings/KSpace exists
     assert dft.numerical_settings is not None
     assert len(dft.numerical_settings) == 1
-    k_mesh = dft.numerical_settings[0]
+    k_space = dft.numerical_settings[0]
+    assert k_space.m_def.name == 'KSpace'
+
+    # Check KSpace.k_mesh exists
+    assert k_space.k_mesh is not None
+    assert len(k_space.k_mesh) == 1
+    k_mesh = k_space.k_mesh[0]
     assert k_mesh.m_def.name == 'KMesh'
 
     # Check k-grid values

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -72,11 +72,21 @@ def test_k_mesh():
     archive = EntryArchive()
     parser.parse('tests/data/fhiaims/Si_geomopt/out.out', archive, LOGGER)
 
-    # Debug: print archive structure
-    print(f"archive.data: {archive.data}")
-    print(f"model_method: {archive.data.model_method if archive.data else None}")
+    # Check DFT section exists
+    assert archive.data.model_method is not None
+    assert len(archive.data.model_method) == 1
+    dft = archive.data.model_method[0]
+    assert dft.m_def.name == 'DFT'
 
-    # For now, skip the test as model_method is not populated
-    # This needs investigation - possibly the DFT method is created elsewhere
-    # or requires normalization
-    pass
+    # Check NumericalSettings/KMesh exists
+    assert dft.numerical_settings is not None
+    assert len(dft.numerical_settings) == 1
+    k_mesh = dft.numerical_settings[0]
+    assert k_mesh.m_def.name == 'KMesh'
+
+    # Check k-grid values
+    assert k_mesh.grid is not None
+    assert list(k_mesh.grid) == [8, 8, 8]
+
+    # k_offset is not in test file, so it should be None
+    assert k_mesh.offset is None

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -94,8 +94,9 @@ def test_k_mesh():
     assert k_mesh.grid is not None
     assert list(k_mesh.grid) == [8, 8, 8]
 
-    # k_offset is not in test file, so it should be None
-    assert k_mesh.offset is None
+    # Check k_offset default (FHI-aims uses Gamma-centered by default)
+    assert k_mesh.offset is not None
+    assert list(k_mesh.offset) == approx([0.0, 0.0, 0.0])
 
 
 def test_k_mesh_with_offset(tmp_path):

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -96,3 +96,52 @@ def test_k_mesh():
 
     # k_offset is not in test file, so it should be None
     assert k_mesh.offset is None
+
+
+def test_k_mesh_with_offset(tmp_path):
+    """Test k-mesh parsing when k_offset is present."""
+    source_path = 'tests/data/fhiaims/Si_geomopt/out.out'
+    with open(source_path, encoding='utf-8') as f:
+        content = f.read()
+
+    # Inject k_offset line after k_grid
+    modified_content = content.replace(
+        '  Found k-point grid:         8         8         8\n',
+        '  Found k-point grid:         8         8         8\n'
+        '  k_offset                           0.5 0.25 0.0\n',
+        1,
+    )
+    assert modified_content != content, 'Failed to inject k_offset line'
+
+    test_file = tmp_path / 'out_with_k_offset.out'
+    test_file.write_text(modified_content, encoding='utf-8')
+
+    parser = FHIAimsParser()
+    archive = EntryArchive()
+    parser.parse(str(test_file), archive, LOGGER)
+
+    # Check DFT section exists
+    assert archive.data.model_method is not None
+    assert len(archive.data.model_method) == 1
+    dft = archive.data.model_method[0]
+    assert dft.m_def.name == 'DFT'
+
+    # Check NumericalSettings/KSpace exists
+    assert dft.numerical_settings is not None
+    assert len(dft.numerical_settings) == 1
+    k_space = dft.numerical_settings[0]
+    assert k_space.m_def.name == 'KSpace'
+
+    # Check KSpace.k_mesh exists
+    assert k_space.k_mesh is not None
+    assert len(k_space.k_mesh) == 1
+    k_mesh = k_space.k_mesh[0]
+    assert k_mesh.m_def.name == 'KMesh'
+
+    # Check k-grid values
+    assert k_mesh.grid is not None
+    assert list(k_mesh.grid) == [8, 8, 8]
+
+    # Check k_offset values
+    assert k_mesh.offset is not None
+    assert list(k_mesh.offset) == approx([0.5, 0.25, 0.0])


### PR DESCRIPTION
## Purpose
Add k-point mesh parsing support for FHI-aims parser, enabling extraction of k-grid and k-offset data from FHI-aims output files and mapping to NOMAD schema.

## Scope

**Included**

- Parse `k_grid` and `k_offset` from FHI-aims output using regex quantities
- Add `KSpace` and `KMesh` schema classes with mapping annotations
- Map parsed data to `DFT.numerical_settings → KSpace → k_mesh → KMesh` hierarchy
- Comprehensive test coverage in `test_fhiaims_parser.py::test_k_mesh`

**Out of scope**

- k-line path parsing
- k-point weights or explicit k-point lists

## Context & Links

Related to FHI-aims parser coverage roadmap (Phase 3.1: Numerical Settings).

Key implementation insight: `KMesh` must be wrapped in `KSpace` (which inherits from `NumericalSettings`) rather than added directly to `DFT.numerical_settings`. This follows the VASP parser pattern.

## Reviewer Notes

The annotation chain is: `DFT` → `KSpace.m_def` → `KSpace.k_mesh` → `KMesh.grid/offset`

All tests pass including the new `test_k_mesh` which validates the complete data flow.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] Unit tests - `test_fhiaims_parser.py::test_k_mesh` validates k-grid parsing and schema mapping
- [x] All existing FHI-aims tests pass

Generated with Claude Code