### PR TITLE
Gromacs: Correct MappingParser usage

### DIFF
--- a/src/nomad_simulation_parsers/parsers/gromacs/parser.py
+++ b/src/nomad_simulation_parsers/parsers/gromacs/parser.py
@@ -75,7 +75,7 @@ class GromacsThermodynamicsParser(MappingParser):
         times = source.get('Time', [])
         outputs = []
         for n, step in enumerate(self._thermodynamic_steps):
-            data = dict(
+            data: dict[str, Any] = dict(
                 step=step,
                 time=times[n] * ureg.picosecond if times[n] is not None else None,
             )
@@ -216,7 +216,7 @@ class GromacsLogParser(TextParser, GromacsThermodynamicsParser):
         outputs = super().get_outputs(data)
         return outputs
 
-    def get_integrator_type(self, integrator: str) -> str:
+    def get_integrator_type(self, integrator: str) -> str | None:
         integrator = (integrator or 'md').lower()
         integrator_map = {
             'steep': 'steepest_descent',
@@ -308,9 +308,7 @@ class GromacsLogParser(TextParser, GromacsThermodynamicsParser):
         )
 
     @staticmethod
-    def _get_grpopts_scalar(
-        input_params: dict[str, Any], key: str
-    ) -> Any:
+    def _get_grpopts_scalar(input_params: dict[str, Any], key: str) -> Any:
         """Read a scalar from grpopts[key], falling back to input_params[key].
 
         Keys are stored with hyphens in grpopts and with underscores at the
@@ -1122,9 +1120,7 @@ class GromacsArchiveWriter(MDParser):
         # LOG/EDR from_dict wrote into target.data back into the root. ForceField
         # contributions are handled by a dedicated pass below, not here.
         self._simulation_parser.annotation_key = gromacs.TPR_KEY
-        self._mdanalysis_parser.convert(
-            self._simulation_parser, update_mode='replace'
-        )
+        self._mdanalysis_parser.convert(self._simulation_parser, update_mode='replace')
 
         # ForceField contributions: target model_method[0] directly, mirroring
         # the XVG/FEP pattern. This avoids depending on from_dict's in-place

--- a/src/nomad_simulation_parsers/parsers/gromacs/parser.py
+++ b/src/nomad_simulation_parsers/parsers/gromacs/parser.py
@@ -12,7 +12,6 @@ from nomad.parsing.file_parser.mapping_parser import (
 from nomad.parsing.parser import MatchingParser
 from nomad.units import ureg
 from nomad.utils import get_logger
-from nomad_simulations.schema_packages import force_field
 from nomad_simulations.schema_packages.force_field import (
     ParticleParametersContainer,
 )
@@ -842,17 +841,18 @@ class GromacsMDAnalysisParser(MappingParser):
         if not interactions:
             return result
 
-        # Filter for bond interactions only
+        # Filter for bond interactions only: bonds have exactly 2 particle indices.
+        # The 'type' field carries inter.btype (a topology-specific string such as
+        # 'CT-CT'), not the literal 'bond', so we identify bonds by particle count.
         bonds = []
         n_bond_particles: int = 2
         for interaction in interactions:
-            if interaction.get('type') == 'bond':
-                particle_indices = interaction.get('atom_indices')
-                if (
-                    particle_indices is not None
-                    and len(particle_indices) == n_bond_particles
-                ):
-                    bonds.append(list(particle_indices))
+            particle_indices = interaction.get('atom_indices')
+            if (
+                particle_indices is not None
+                and len(particle_indices) == n_bond_particles
+            ):
+                bonds.append(list(particle_indices))
 
         if bonds:
             result = np.array(bonds, dtype=int)
@@ -1117,66 +1117,29 @@ class GromacsArchiveWriter(MDParser):
         self._simulation_parser.annotation_key = gromacs.EDR_KEY
         self._edr_parser.convert(self._simulation_parser)
 
-        # parse mdanalysis trajectory files
+        # parse mdanalysis trajectory files (model_system data only)
+        # Use update_mode='replace' to avoid merging the old plain-key dicts that
+        # LOG/EDR from_dict wrote into target.data back into the root. ForceField
+        # contributions are handled by a dedicated pass below, not here.
         self._simulation_parser.annotation_key = gromacs.TPR_KEY
-        self._mdanalysis_parser.convert(self._simulation_parser)
+        self._mdanalysis_parser.convert(
+            self._simulation_parser, update_mode='replace'
+        )
 
-        # TODO: The three explicit instantiation blocks below (ForceField,
-        # ForceCalculations, ParticleParametersContainer) are required because of a
-        # silent data-loss pattern in MetainfoParser.from_dict (mapping_parser.py):
-        # when a second convert() pass targets a repeating SubSection whose index 0
-        # already holds an instance of a different concrete type, from_dict recurses
-        # into that existing instance and attempts to set quantities on it. Those
-        # quantities are absent from the wrong type, so m_set skips them silently.
-        # The post-write emptiness check (from_dict ~L2187) then removes the
-        # subsection because nothing was written. The data is silently dropped.
-        # Workaround: instantiate the target concrete type explicitly and run a
-        # dedicated convert() pass with that instance as data_object, then append
-        # it to the list manually. See also gromacs.py Simulation TODO.
+        # ForceField contributions: target model_method[0] directly, mirroring
+        # the XVG/FEP pattern. This avoids depending on from_dict's in-place
+        # sub-section update behaviour to preserve numerical_settings across passes.
+        # ForceField.m_def has no TPR_KEY annotation so the Simulation-level TPR
+        # pass above does not touch model_method; this pass is authoritative.
+        if self.archive.data.model_method:
+            self._simulation_parser.data_object = self.archive.data.model_method[0]
+            self._simulation_parser.annotation_key = gromacs.TPR_KEY
+            self._simulation_parser.mapper = None
+            self._mdanalysis_parser.convert(self._simulation_parser)
+            self._simulation_parser.data_object = self.archive.data
 
-        # --- from_dict silent-drop workaround: ForceField ---
-        # model_method[0] (MolecularDynamicsMethod, from LOG pass) already exists;
-        # a TPR pass via annotations would silently drop ForceField data into it.
-        # Instantiate explicitly and target ff directly.
-        ff = gromacs.ForceField()
-        self._simulation_parser.data_object = ff
-        self._simulation_parser.annotation_key = gromacs.TPR_KEY
-        self._mdanalysis_parser.convert(self._simulation_parser)
-
-        # --- annotation gap workaround: ForceField.contributions ---
-        # build_section_mapper skips a SubSection if its child quantities have no
-        # annotations for the current key (L2341), even when the SubSection itself
-        # has an m_def annotation. The loop below replaces:
-        #   add_mapping_annotation(
-        #       force_field.ForceField.contributions, TPR_KEY,
-        #       ('get_force_field_contributions', [])
-        #   )
-        for contrib in self._mdanalysis_parser.get_force_field_contributions():
-            ff.contributions.append(
-                force_field.Potential(
-                    functional_form=contrib.get('functional_form'),
-                    particle_indices=np.array(contrib['particle_indices']),
-                    # TODO: particle_labels is a numpy array of strings; archive
-                    # string quantities are treated as potential keywords, triggering
-                    # numpy ambiguous-truth-value error on `if keyword:`.
-                    # particle_labels=contrib.get('particle_labels'),
-                )
-            )
-
-        # --- from_dict silent-drop workaround: ForceCalculations ---
-        # numerical_settings[0] would already exist if LOG annotations ran via
-        # ForceField.m_def (they don't, by design — see above). Targeting fc directly
-        # avoids the index-0 collision and appends cleanly.
-        fc = gromacs.ForceCalculations()
-        self._simulation_parser.data_object = fc
-        self._simulation_parser.annotation_key = gromacs.LOG_KEY
-        self._log_parser.convert(self._simulation_parser)
-        ff.numerical_settings.append(fc)
-        self.archive.data.model_method.append(ff)
-
-        # --- from_dict silent-drop workaround: ParticleParametersContainer ---
-        # numerical_settings[0] already holds ForceCalculations; a second pass via
-        # annotations would silently drop ppc data into it. Target ppc directly.
+        # ParticleParametersContainer: no annotation path from Simulation to
+        # model_method for PARTICLE_PARAM_KEY; target directly.
         if self.archive.data.model_method:
             ppc = ParticleParametersContainer()
             self._simulation_parser.data_object = ppc

--- a/src/nomad_simulation_parsers/parsers/gromacs/parser.py
+++ b/src/nomad_simulation_parsers/parsers/gromacs/parser.py
@@ -1129,8 +1129,9 @@ class GromacsArchiveWriter(MDParser):
         # ForceField contributions: target model_method[0] directly, mirroring
         # the XVG/FEP pattern. This avoids depending on from_dict's in-place
         # sub-section update behaviour to preserve numerical_settings across passes.
-        # ForceField.m_def has no TPR_KEY annotation so the Simulation-level TPR
-        # pass above does not touch model_method; this pass is authoritative.
+        # The Simulation-level TPR pass above has no Simulation->model_method
+        # mapping for TPR_KEY, so it does not traverse model_method; this pass
+        # is authoritative for ForceField content.
         if self.archive.data.model_method:
             self._simulation_parser.data_object = self.archive.data.model_method[0]
             self._simulation_parser.annotation_key = gromacs.TPR_KEY

--- a/src/nomad_simulation_parsers/schema_packages/gromacs.py
+++ b/src/nomad_simulation_parsers/schema_packages/gromacs.py
@@ -204,10 +204,10 @@ class Simulation(general.Simulation):
     add_mapping_annotation(
         general.Simulation.model_system, TPR_KEY, ('get_configurations', [])
     )
-    # ForceField is populated via the annotation-driven LOG and TPR passes
-    # (both target archive.data). ForceField.m_def has LOG_KEY and TPR_KEY '@',
-    # so the LOG pass creates ForceField in model_method via polymorphism and
-    # the TPR pass (update_mode='merge') merges contributions into it.
+    # The LOG pass on archive.data creates ForceField in model_method via
+    # ModelMethod polymorphism. ForceField-specific TPR contributions are then
+    # applied by a dedicated pass in parser.py that targets model_method[0]
+    # directly; they do not come from the Simulation-level TPR pass here.
 
 
 add_mapping_annotation(Outputs.m_def, LOG_KEY, ('get_outputs', []))

--- a/src/nomad_simulation_parsers/schema_packages/gromacs.py
+++ b/src/nomad_simulation_parsers/schema_packages/gromacs.py
@@ -204,15 +204,10 @@ class Simulation(general.Simulation):
     add_mapping_annotation(
         general.Simulation.model_system, TPR_KEY, ('get_configurations', [])
     )
-    # TODO: Replace explicit ForceField + ForceCalculations instantiation in
-    # parser.py._parse_data_section if the upstream silent-drop issue is fixed.
-    # Root cause: MetainfoParser.from_dict (mapping_parser.py ~L2171) finds the
-    # already-existing model_method[0] (MolecularDynamicsMethod from LOG pass) and
-    # recurses into it for the TPR pass. Quantities from ForceField are absent on
-    # MolecularDynamicsMethod, so m_set skips them silently. The post-write
-    # emptiness check (~L2187) then removes the subsection. Data is silently dropped.
-    # Until fixed: instantiate ForceField explicitly and target it directly.
-    # See parser.py._parse_data_section for the workaround blocks.
+    # ForceField is populated via the annotation-driven LOG and TPR passes
+    # (both target archive.data). ForceField.m_def has LOG_KEY and TPR_KEY '@',
+    # so the LOG pass creates ForceField in model_method via polymorphism and
+    # the TPR pass (update_mode='merge') merges contributions into it.
 
 
 add_mapping_annotation(Outputs.m_def, LOG_KEY, ('get_outputs', []))
@@ -502,14 +497,25 @@ add_mapping_annotation(molecular_dynamics.MolecularDynamics.m_def, LOG_KEY, '@')
 
 
 # Force Field
-# Explicit instantiation in parser.py is required: a second convert() pass would
-# silently drop ForceField data because from_dict finds the existing model_method[0]
-# (MolecularDynamicsMethod) and attempts to set ForceField quantities on it — they
-# are absent, skipped silently, and the emptiness check removes the subsection.
+# LOG pass on archive.data (Simulation):
+# - ForceField.m_def has LOG_KEY '@': LOG pass creates ForceField in model_method
+#   via ModelMethod polymorphism; ForceCalculations populated via numerical_settings
+#   recursion (ForceCalculations.m_def has LOG_KEY '@').
+# TPR contributions pass in parser.py:
+# - After the Simulation-level TPR pass (model_system only), parser.py targets
+#   model_method[0] (the existing ForceField instance) directly as data_object and
+#   runs a dedicated convert with TPR_KEY. This mirrors the XVG/FEP pattern and
+#   avoids depending on from_dict's in-place sub-section update behaviour.
+# ParticleParametersContainer uses a dedicated PARTICLE_PARAM_KEY pass in parser.py.
 class ForceField(force_field.ForceField):
-    pass
+    add_mapping_annotation(
+        force_field.ForceField.contributions,
+        TPR_KEY,
+        ('get_force_field_contributions', []),
+    )
 
 
+add_mapping_annotation(ForceField.m_def, LOG_KEY, '@')
 add_mapping_annotation(ForceField.m_def, TPR_KEY, '@')
 
 
@@ -539,12 +545,20 @@ class ForceCalculations(force_field.ForceCalculations):
 
 
 add_mapping_annotation(force_field.Potential.m_def, TPR_KEY, '@')
+add_mapping_annotation(
+    force_field.Potential.functional_form, TPR_KEY, '.functional_form'
+)
+add_mapping_annotation(
+    force_field.Potential.particle_indices, TPR_KEY, '.particle_indices'
+)
+# NOTE: particle_labels is intentionally not annotated — it is a numpy array of
+# strings; archive string quantities are treated as potential keywords, which
+# triggers a numpy ambiguous-truth-value error on `if keyword:`.
 add_mapping_annotation(force_field.ForceCalculations.m_def, LOG_KEY, '@')
 
 # ParticleParametersContainer is populated via a dedicated PARTICLE_PARAM_KEY convert
 # pass that targets a fresh ParticleParametersContainer() as data_object, then
-# appends it to ForceField.numerical_settings in parser.py. This avoids the
-# index-0 collision with ForceCalculations written by the earlier LOG pass.
+# appended to ForceField.numerical_settings in parser.py.
 add_mapping_annotation(
     force_field.ParticleParametersContainer.m_def, PARTICLE_PARAM_KEY, '@'
 )

--- a/tests/parsers/test_gromacs_parser.py
+++ b/tests/parsers/test_gromacs_parser.py
@@ -256,15 +256,23 @@ def test_get_coordinate_save_frequency():
 
 
 def test_get_bond_list():
-    """Test bond list extraction from MDAnalysis interactions."""
+    """Test bond list extraction from MDAnalysis interactions.
+
+    MDAnalysis sets inter.btype to a topology-specific string (e.g. 'OW-HW'),
+    never to the literal 'bond'. Bonds are identified solely by having exactly
+    2 particle indices.
+    """
     mdap = gromacs_parser.GromacsMDAnalysisParser()
 
-    # Test with bond interactions
     mock_interactions = [
-        {'type': 'bond', 'atom_indices': [0, 1], 'atom_labels': ['O', 'H']},
-        {'type': 'bond', 'atom_indices': [0, 2], 'atom_labels': ['O', 'H']},
-        {'type': 'bond', 'atom_indices': [3, 4], 'atom_labels': ['O', 'H']},
-        {'type': 'angle', 'atom_indices': [1, 0, 2], 'atom_labels': ['H', 'O', 'H']},
+        {'type': 'OW-HW', 'atom_indices': [0, 1], 'atom_labels': ['OW', 'HW']},
+        {'type': 'OW-HW', 'atom_indices': [0, 2], 'atom_labels': ['OW', 'HW']},
+        {'type': 'CT-CT', 'atom_indices': [3, 4], 'atom_labels': ['CT', 'CT']},
+        {
+            'type': 'HW-OW-HW',
+            'atom_indices': [1, 0, 2],
+            'atom_labels': ['HW', 'OW', 'HW'],
+        },
     ]
 
     mdap.data_object = StubInteractionsDataObject(mock_interactions)
@@ -280,12 +288,11 @@ def test_get_bond_list():
 
 
 def test_get_bond_list_no_bonds():
-    """Test bond list extraction when no bonds are present."""
+    """Test bond list extraction when only higher-order interactions are present."""
     mdap = gromacs_parser.GromacsMDAnalysisParser()
 
-    # Only angles, no bonds
     mock_interactions = [
-        {'type': 'angle', 'atom_indices': [0, 1, 2], 'atom_labels': ['H', 'O', 'H']},
+        {'type': 'HW-OW-HW', 'atom_indices': [0, 1, 2], 'atom_labels': ['H', 'O', 'H']},
     ]
 
     mdap.data_object = StubInteractionsDataObject(mock_interactions)
@@ -305,15 +312,18 @@ def test_get_bond_list_empty_interactions():
 
 
 def test_get_bond_list_invalid_bond_indices():
-    """Test bond list extraction filters out invalid bond entries."""
+    """Test bond list extraction skips entries with None or wrong-count indices."""
     mdap = gromacs_parser.GromacsMDAnalysisParser()
 
-    # Mix of valid and invalid bond interactions
     mock_interactions = [
-        {'type': 'bond', 'atom_indices': [0, 1], 'atom_labels': ['O', 'H']},
-        {'type': 'bond', 'atom_indices': None, 'atom_labels': ['O', 'H']},
-        {'type': 'bond', 'atom_indices': [2, 3, 4], 'atom_labels': ['O', 'H', 'C']},
-        {'type': 'bond', 'atom_indices': [4, 5], 'atom_labels': ['O', 'H']},
+        {'type': 'OW-HW', 'atom_indices': [0, 1], 'atom_labels': ['OW', 'HW']},
+        {'type': 'OW-HW', 'atom_indices': None, 'atom_labels': ['OW', 'HW']},
+        {
+            'type': 'OW-HW-XX',
+            'atom_indices': [2, 3, 4],
+            'atom_labels': ['OW', 'HW', 'XX'],
+        },
+        {'type': 'CT-CT', 'atom_indices': [4, 5], 'atom_labels': ['CT', 'CT']},
     ]
 
     mdap.data_object = StubInteractionsDataObject(mock_interactions)


### PR DESCRIPTION
## Purpose

Correct two instances of incorrect MappingParser usage in the GROMACS parser.

1. **`get_bond_list()`** — removed incorrect `type == 'bond'` filter; MDAnalysis `inter.btype`
   is a topology-specific string (e.g. `'OW-HW'`), not the literal `'bond'`. Bonds are now
   identified by particle count (exactly 2 indices).

2. **`_parse_data_section` / `gromacs.py`** — replaced ~60 lines of explicit `ForceField`,
   `ForceCalculations`, and `ParticleParametersContainer` instantiation with a targeted pass
   (`data_object = model_method[0]`) and moved the corresponding annotations
   (`ForceField.contributions`, `Potential.functional_form`, `Potential.particle_indices`)
   into `gromacs.py` where they belong.

## Scope

**Included**

- `parsers/gromacs/parser.py`: all corrections above
- `schema_packages/gromacs.py`: `ForceField.contributions`, `Potential.functional_form`,
  `Potential.particle_indices` annotations added
- `tests/parsers/test_gromacs_parser.py`: four bond_list unit tests updated to use
  realistic MDAnalysis btype strings; integration test for bond count added

**Out of scope**

- `ResultsNormalizer` schema gap — requires changes in `nomad-FAIR`: Visualization not tested!

## Reviewer Notes

`ForceField.m_def TPR_KEY '@'` retained as the source root anchor for the targeted
`model_method[0]` pass.

`particle_labels` is intentionally not annotated: numpy string arrays trigger an
ambiguous-truth-value error when treated as archive keywords.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing (water example; 432 bonds in `model_system[0].bond_list`;
  ForceField contributions present)