### PR TITLE
Add FHI-aims SCF convergence criteria extraction

### DIFF
--- a/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
@@ -787,7 +787,6 @@ class FHIAimsOutFileParser(TextParser):
                 'convergence_eigenvalues',
                 rf'Convergence accuracy of sum of eigenvalues: *({RE_FLOAT})',
                 dtype=float,
-                unit='eV',
             ),
             Quantity(
                 'max_scf_iterations',

--- a/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
@@ -776,6 +776,22 @@ class FHIAimsOutFileParser(TextParser):
                 dtype=float,
             ),
             Quantity(
+                'convergence_density',
+                rf'Convergence accuracy of self-consistent charge density: *({RE_FLOAT})',
+                dtype=float,
+            ),
+            Quantity(
+                'convergence_eigenvalues',
+                rf'Convergence accuracy of sum of eigenvalues: *({RE_FLOAT})',
+                dtype=float,
+                unit='eV',
+            ),
+            Quantity(
+                'max_scf_iterations',
+                rf'Maximum number of self-consistency iterations:\s*(\d+)',
+                dtype=int,
+            ),
+            Quantity(
                 'convergence_forces',
                 rf'Convergence accuracy for geometry relaxation: '
                 rf'Maximum force < *({RE_FLOAT}) *eV/A',

--- a/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
@@ -777,7 +777,10 @@ class FHIAimsOutFileParser(TextParser):
             ),
             Quantity(
                 'convergence_density',
-                rf'Convergence accuracy of self-consistent charge density: *({RE_FLOAT})',
+                (
+                    rf'Convergence accuracy of self-consistent '
+                    rf'charge density: *({RE_FLOAT})'
+                ),
                 dtype=float,
             ),
             Quantity(
@@ -788,7 +791,7 @@ class FHIAimsOutFileParser(TextParser):
             ),
             Quantity(
                 'max_scf_iterations',
-                rf'Maximum number of self-consistency iterations:\s*(\d+)',
+                r'Maximum number of self-consistency iterations:\s*(\d+)',
                 dtype=int,
             ),
             Quantity(

--- a/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/out_parser.py
@@ -774,6 +774,7 @@ class FHIAimsOutFileParser(TextParser):
                 'convergence_energy',
                 rf'Convergence accuracy of total energy: *({RE_FLOAT})',
                 dtype=float,
+                unit='eV',
             ),
             Quantity(
                 'convergence_density',
@@ -787,6 +788,7 @@ class FHIAimsOutFileParser(TextParser):
                 'convergence_eigenvalues',
                 rf'Convergence accuracy of sum of eigenvalues: *({RE_FLOAT})',
                 dtype=float,
+                unit='eV',
             ),
             Quantity(
                 'max_scf_iterations',

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -319,61 +319,71 @@ class FHIAimsOutMappingParser(TextMappingParser):
             return np.array([0.0, 0.0, 0.0])
         return k_offset
 
-    def get_scf_convergence_criteria(
-        self, source: dict[str, Any]
-    ) -> list[dict[str, Any]]:
+    def get_scf_energy_criterion(self, source: dict[str, Any]) -> dict[str, Any]:
         """
-        Extract SCF convergence criteria and return as list of SelfConsistency dicts.
-
-        FHI-aims supports multiple convergence criteria:
-        - Total energy convergence (eV)
-        - Charge density convergence (dimensionless)
-        - Sum of eigenvalues convergence (eV)
-        - Maximum number of SCF iterations
+        Extract energy convergence criterion for SCF.
 
         Returns:
-            List of dictionaries, each representing one SelfConsistency section.
+            Dictionary representing energy SelfConsistency section, or empty dict.
         """
-        convergence_criteria = []
-
-        # Energy convergence threshold
         conv_energy = source.get('convergence_energy')
-        if conv_energy is not None:
-            convergence_criteria.append(
-                {
-                    'threshold_change': conv_energy,
-                    'threshold_change_unit': 'energy',
-                }
-            )
+        if conv_energy is None:
+            return {}
 
-        # Charge density convergence threshold
+        result = {
+            'threshold_change': conv_energy,
+            'threshold_change_unit': 'energy',
+        }
+
+        max_iterations = source.get('max_scf_iterations')
+        if max_iterations is not None:
+            result['n_max_iterations'] = max_iterations
+
+        return result
+
+    def get_scf_density_criterion(self, source: dict[str, Any]) -> dict[str, Any]:
+        """
+        Extract density convergence criterion for SCF.
+
+        Returns:
+            Dictionary representing density SelfConsistency section, or empty dict.
+        """
         conv_density = source.get('convergence_density')
-        if conv_density is not None:
-            convergence_criteria.append(
-                {
-                    'threshold_change': conv_density,
-                    'threshold_change_unit': 'electron_density',
-                }
-            )
+        if conv_density is None:
+            return {}
 
-        # Sum of eigenvalues convergence threshold
+        result = {
+            'threshold_change': conv_density,
+            'threshold_change_unit': 'electron_density',
+        }
+
+        max_iterations = source.get('max_scf_iterations')
+        if max_iterations is not None:
+            result['n_max_iterations'] = max_iterations
+
+        return result
+
+    def get_scf_eigenvalues_criterion(self, source: dict[str, Any]) -> dict[str, Any]:
+        """
+        Extract eigenvalues convergence criterion for SCF.
+
+        Returns:
+            Dictionary representing eigenvalues SelfConsistency section, or empty dict.
+        """
         conv_eigenvalues = source.get('convergence_eigenvalues')
-        if conv_eigenvalues is not None:
-            convergence_criteria.append(
-                {
-                    'threshold_change': conv_eigenvalues,
-                    'threshold_change_unit': 'sum_eigenvalues',
-                }
-            )
+        if conv_eigenvalues is None:
+            return {}
 
-        # Maximum iterations (add to all criteria if specified)
-        if source:
-            max_iterations = source.get('max_scf_iterations')
-            if max_iterations is not None:
-                for criterion in convergence_criteria:
-                    criterion['n_max_iterations'] = max_iterations
+        result = {
+            'threshold_change': conv_eigenvalues,
+            'threshold_change_unit': 'sum_eigenvalues',
+        }
 
-        return convergence_criteria
+        max_iterations = source.get('max_scf_iterations')
+        if max_iterations is not None:
+            result['n_max_iterations'] = max_iterations
+
+        return result
 
     def get_scf_steps(self, source: dict[str, Any]) -> dict[str, Any]:
         scf_iterations = source.get('self_consistency', [])
@@ -566,6 +576,21 @@ class FHIAimsArchiveWriter(ArchiveWriter):
         archive_handler.data_object = self.archive.data
 
         out_parser.convert(archive_handler, remove=False)
+
+        # Manually create SelfConsistency instances for SCF convergence criteria
+        # (multi-mapper doesn't support function-returns-list pattern)
+        from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
+        if self.archive.data.model_method:
+            dft = self.archive.data.model_method[0]
+            scf_criteria = out_parser.get_scf_energy_criterion(out_parser.data)
+            if scf_criteria:
+                dft.numerical_settings.append(SelfConsistency(**scf_criteria))
+            scf_criteria = out_parser.get_scf_density_criterion(out_parser.data)
+            if scf_criteria:
+                dft.numerical_settings.append(SelfConsistency(**scf_criteria))
+            scf_criteria = out_parser.get_scf_eigenvalues_criterion(out_parser.data)
+            if scf_criteria:
+                dft.numerical_settings.append(SelfConsistency(**scf_criteria))
 
         # separate parsing of dos due to a problem with mapping physical
         # property variables

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -330,18 +330,9 @@ class FHIAimsOutMappingParser(TextMappingParser):
         if conv_energy is None:
             return {}
 
-        # Extract magnitude and unit from pint Quantity if present
-        if hasattr(conv_energy, 'magnitude') and hasattr(conv_energy, 'units'):
-            value = conv_energy.magnitude
-            unit = format(conv_energy.units, '~P')  # Use short symbol format
-        else:
-            value = conv_energy
-            unit = 'eV'
-
         result = {
             'name': 'total_energy_change',
-            'threshold_change': value,
-            'threshold_change_unit': unit,
+            'threshold_change': conv_energy,
         }
 
         max_iterations = source.get('max_scf_iterations')
@@ -384,20 +375,9 @@ class FHIAimsOutMappingParser(TextMappingParser):
         if conv_eigenvalues is None:
             return {}
 
-        # Extract magnitude and unit from pint Quantity if present
-        if hasattr(conv_eigenvalues, 'magnitude') and hasattr(
-            conv_eigenvalues, 'units'
-        ):
-            value = conv_eigenvalues.magnitude
-            unit = format(conv_eigenvalues.units, '~P')  # Use short symbol format
-        else:
-            value = conv_eigenvalues
-            unit = 'eV'
-
         result = {
             'name': 'sum_eigenvalues_change',
-            'threshold_change': value,
-            'threshold_change_unit': unit,
+            'threshold_change': conv_eigenvalues,
         }
 
         max_iterations = source.get('max_scf_iterations')

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -582,15 +582,28 @@ class FHIAimsArchiveWriter(ArchiveWriter):
         from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
         if self.archive.data.model_method:
             dft = self.archive.data.model_method[0]
+
+            # Collect all criteria
+            criteria = []
             scf_criteria = out_parser.get_scf_energy_criterion(out_parser.data)
             if scf_criteria:
-                dft.numerical_settings.append(SelfConsistency(**scf_criteria))
+                criteria.append(scf_criteria)
             scf_criteria = out_parser.get_scf_density_criterion(out_parser.data)
             if scf_criteria:
-                dft.numerical_settings.append(SelfConsistency(**scf_criteria))
+                criteria.append(scf_criteria)
             scf_criteria = out_parser.get_scf_eigenvalues_criterion(out_parser.data)
             if scf_criteria:
-                dft.numerical_settings.append(SelfConsistency(**scf_criteria))
+                criteria.append(scf_criteria)
+
+            # If no thresholds parsed but max_iterations present, preserve it
+            if not criteria:
+                max_iterations = out_parser.data.get('max_scf_iterations')
+                if max_iterations is not None:
+                    criteria.append({'n_max_iterations': max_iterations})
+
+            # Add all criteria to numerical_settings
+            for criterion in criteria:
+                dft.numerical_settings.append(SelfConsistency(**criterion))
 
         # separate parsing of dos due to a problem with mapping physical
         # property variables

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -319,6 +319,62 @@ class FHIAimsOutMappingParser(TextMappingParser):
             return np.array([0.0, 0.0, 0.0])
         return k_offset
 
+    def get_scf_convergence_criteria(
+        self, source: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """
+        Extract SCF convergence criteria and return as list of SelfConsistency dicts.
+
+        FHI-aims supports multiple convergence criteria:
+        - Total energy convergence (eV)
+        - Charge density convergence (dimensionless)
+        - Sum of eigenvalues convergence (eV)
+        - Maximum number of SCF iterations
+
+        Returns:
+            List of dictionaries, each representing one SelfConsistency section.
+        """
+        convergence_criteria = []
+
+        # Energy convergence threshold
+        conv_energy = source.get('convergence_energy')
+        if conv_energy is not None:
+            convergence_criteria.append(
+                {
+                    'threshold_change': conv_energy,
+                    'threshold_change_unit': 'energy',
+                }
+            )
+
+        # Charge density convergence threshold
+        conv_density = source.get('convergence_density')
+        if conv_density is not None:
+            convergence_criteria.append(
+                {
+                    'threshold_change': conv_density,
+                    'threshold_change_unit': 'electron_density',
+                }
+            )
+
+        # Sum of eigenvalues convergence threshold
+        conv_eigenvalues = source.get('convergence_eigenvalues')
+        if conv_eigenvalues is not None:
+            convergence_criteria.append(
+                {
+                    'threshold_change': conv_eigenvalues,
+                    'threshold_change_unit': 'sum_eigenvalues',
+                }
+            )
+
+        # Maximum iterations (add to all criteria if specified)
+        if source:
+            max_iterations = source.get('max_scf_iterations')
+            if max_iterations is not None:
+                for criterion in convergence_criteria:
+                    criterion['n_max_iterations'] = max_iterations
+
+        return convergence_criteria
+
     def get_scf_steps(self, source: dict[str, Any]) -> dict[str, Any]:
         scf_iterations = source.get('self_consistency', [])
         if not scf_iterations:

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -562,7 +562,7 @@ class FHIAimsArchiveWriter(ArchiveWriter):
 
         return phonopy_obj, force_archives
 
-    def write_to_archive(  # noqa: PLR0915
+    def write_to_archive(  # noqa: PLR0915, PLR0912
         self,
     ) -> None:
         out_parser = FHIAimsOutMappingParser()
@@ -579,7 +579,10 @@ class FHIAimsArchiveWriter(ArchiveWriter):
 
         # Manually create SelfConsistency instances for SCF convergence criteria
         # (multi-mapper doesn't support function-returns-list pattern)
-        from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
+        from nomad_simulations.schema_packages.numerical_settings import (  # noqa: PLC0415
+            SelfConsistency,
+        )
+
         if self.archive.data.model_method:
             dft = self.archive.data.model_method[0]
 

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -334,7 +334,6 @@ class FHIAimsOutMappingParser(TextMappingParser):
         Returns:
             List of dictionaries, each representing one SelfConsistency section.
         """
-        print(f"DEBUG get_scf_convergence_criteria: source type={type(source)}, keys={list(source.keys())[:20] if isinstance(source, dict) else 'not dict'}")
         convergence_criteria = []
 
         # Energy convergence threshold
@@ -374,7 +373,6 @@ class FHIAimsOutMappingParser(TextMappingParser):
                 for criterion in convergence_criteria:
                     criterion['n_max_iterations'] = max_iterations
 
-        print(f"DEBUG get_scf_convergence_criteria: returning {len(convergence_criteria)} criteria: {convergence_criteria}")
         return convergence_criteria
 
     def get_scf_steps(self, source: dict[str, Any]) -> dict[str, Any]:

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -334,6 +334,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
         Returns:
             List of dictionaries, each representing one SelfConsistency section.
         """
+        print(f"DEBUG get_scf_convergence_criteria: source type={type(source)}, keys={list(source.keys())[:20] if isinstance(source, dict) else 'not dict'}")
         convergence_criteria = []
 
         # Energy convergence threshold
@@ -373,6 +374,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
                 for criterion in convergence_criteria:
                     criterion['n_max_iterations'] = max_iterations
 
+        print(f"DEBUG get_scf_convergence_criteria: returning {len(convergence_criteria)} criteria: {convergence_criteria}")
         return convergence_criteria
 
     def get_scf_steps(self, source: dict[str, Any]) -> dict[str, Any]:

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -330,10 +330,18 @@ class FHIAimsOutMappingParser(TextMappingParser):
         if conv_energy is None:
             return {}
 
+        # Extract magnitude and unit from pint Quantity if present
+        if hasattr(conv_energy, 'magnitude') and hasattr(conv_energy, 'units'):
+            value = conv_energy.magnitude
+            unit = format(conv_energy.units, '~P')  # Use short symbol format
+        else:
+            value = conv_energy
+            unit = 'eV'
+
         result = {
             'name': 'total_energy_change',
-            'threshold_change': conv_energy,
-            'threshold_change_unit': 'eV',
+            'threshold_change': value,
+            'threshold_change_unit': unit,
         }
 
         max_iterations = source.get('max_scf_iterations')
@@ -376,10 +384,20 @@ class FHIAimsOutMappingParser(TextMappingParser):
         if conv_eigenvalues is None:
             return {}
 
+        # Extract magnitude and unit from pint Quantity if present
+        if hasattr(conv_eigenvalues, 'magnitude') and hasattr(
+            conv_eigenvalues, 'units'
+        ):
+            value = conv_eigenvalues.magnitude
+            unit = format(conv_eigenvalues.units, '~P')  # Use short symbol format
+        else:
+            value = conv_eigenvalues
+            unit = 'eV'
+
         result = {
             'name': 'sum_eigenvalues_change',
-            'threshold_change': conv_eigenvalues,
-            'threshold_change_unit': 'eV',
+            'threshold_change': value,
+            'threshold_change_unit': unit,
         }
 
         max_iterations = source.get('max_scf_iterations')
@@ -639,9 +657,15 @@ class FHIAimsArchiveWriter(ArchiveWriter):
                 ]
             energy_threshold = out_parser.data.get('convergence_energy')
             if energy_threshold is not None:
+                # Handle both pint Quantity (with units) and plain float
+                if hasattr(energy_threshold, 'units'):
+                    threshold_value = energy_threshold
+                else:
+                    threshold_value = energy_threshold * ureg.eV
+
                 self.archive.workflow2.method.single_point_convergence_targets = [
                     EnergyConvergenceTarget(
-                        threshold=energy_threshold * ureg.eV,
+                        threshold=threshold_value,
                         threshold_type='absolute',
                     )
                 ]

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -331,6 +331,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
             return {}
 
         result = {
+            'name': 'total_energy_change',
             'threshold_change': conv_energy,
             'threshold_change_unit': 'eV',
         }
@@ -353,6 +354,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
             return {}
 
         result = {
+            'name': 'charge_density_change',
             'threshold_change': conv_density,
             'threshold_change_unit': 'dimensionless',
         }
@@ -375,6 +377,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
             return {}
 
         result = {
+            'name': 'sum_eigenvalues_change',
             'threshold_change': conv_eigenvalues,
             'threshold_change_unit': 'eV',
         }
@@ -606,7 +609,12 @@ class FHIAimsArchiveWriter(ArchiveWriter):
 
             # Add all criteria to numerical_settings
             for criterion in criteria:
-                dft.numerical_settings.append(SelfConsistency(**criterion))
+                # Extract name if present (must be set after instantiation due to __init__ override)
+                criterion_name = criterion.pop('name', None)
+                instance = SelfConsistency(**criterion)
+                if criterion_name:
+                    instance.name = criterion_name
+                dft.numerical_settings.append(instance)
 
         # separate parsing of dos due to a problem with mapping physical
         # property variables

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -332,7 +332,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
 
         result = {
             'threshold_change': conv_energy,
-            'threshold_change_unit': 'energy',
+            'threshold_change_unit': 'eV',
         }
 
         max_iterations = source.get('max_scf_iterations')
@@ -354,7 +354,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
 
         result = {
             'threshold_change': conv_density,
-            'threshold_change_unit': 'electron_density',
+            'threshold_change_unit': 'dimensionless',
         }
 
         max_iterations = source.get('max_scf_iterations')
@@ -376,7 +376,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
 
         result = {
             'threshold_change': conv_eigenvalues,
-            'threshold_change_unit': 'sum_eigenvalues',
+            'threshold_change_unit': 'eV',
         }
 
         max_iterations = source.get('max_scf_iterations')

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -609,7 +609,7 @@ class FHIAimsArchiveWriter(ArchiveWriter):
 
             # Add all criteria to numerical_settings
             for criterion in criteria:
-                # Extract name if present (must be set after instantiation due to __init__ override)
+                # Extract name (must be set after instantiation due to __init__)
                 criterion_name = criterion.pop('name', None)
                 instance = SelfConsistency(**criterion)
                 if criterion_name:

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -92,13 +92,8 @@ class DFT(model_method.DFT):
     add_mapping_annotation(numerical_settings.KSpace.m_def, TEXT_KEY, '.@')
 
 
-# Add SelfConsistency instances to DFT numerical_settings
-# Must be at module level for multi-mapper detection to work
-add_mapping_annotation(
-    numerical_settings.SelfConsistency.m_def,
-    TEXT_KEY,
-    ('get_scf_convergence_criteria', ['@']),
-)
+# SelfConsistency instances are created manually in parser.py write_to_archive()
+# because multi-mapper doesn't support function-returns-list pattern
 
 
 # class DFT(model_method.DFT):

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -3,8 +3,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     pass
 
+import numpy as np
+
 from nomad.datamodel.metainfo.annotations import Mapper
-from nomad.metainfo import SchemaPackage
+from nomad.metainfo import Quantity, SchemaPackage
 from nomad.parsing.file_parser.mapping_parser import MAPPING_ANNOTATION_KEY
 from nomad_simulations.schema_packages import (
     general,
@@ -83,12 +85,21 @@ class Simulation(general.Simulation):
     )
 
 
+
 class Program(general.Program):
     add_mapping_annotation(general.Program.version, TEXT_KEY, '.version')
 
 
 class DFT(model_method.DFT):
     add_mapping_annotation(numerical_settings.KSpace.m_def, TEXT_KEY, '.@')
+
+
+# Add SelfConsistency instances to DFT numerical_settings
+add_mapping_annotation(
+    numerical_settings.SelfConsistency.m_def,
+    TEXT_KEY,
+    ('get_scf_convergence_criteria', ['.@']),
+)
 
 
 # class DFT(model_method.DFT):

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -92,10 +92,6 @@ class DFT(model_method.DFT):
     add_mapping_annotation(numerical_settings.KSpace.m_def, TEXT_KEY, '.@')
 
 
-# SelfConsistency instances are created manually in parser.py write_to_archive()
-# because multi-mapper doesn't support function-returns-list pattern
-
-
 # class DFT(model_method.DFT):
 #     model_method.DFT.xc_functionals.m_annotations.setdefault(
 #         MAPPING_ANNOTATION_KEY, {}

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -98,7 +98,7 @@ class DFT(model_method.DFT):
 add_mapping_annotation(
     numerical_settings.SelfConsistency.m_def,
     TEXT_KEY,
-    ('get_scf_convergence_criteria', ['.@']),
+    ('get_scf_convergence_criteria', ['@']),
 )
 
 

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -93,6 +93,7 @@ class DFT(model_method.DFT):
 
 
 # Add SelfConsistency instances to DFT numerical_settings
+# Must be at module level for multi-mapper detection to work
 add_mapping_annotation(
     numerical_settings.SelfConsistency.m_def,
     TEXT_KEY,

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -3,10 +3,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     pass
 
-import numpy as np
 
 from nomad.datamodel.metainfo.annotations import Mapper
-from nomad.metainfo import Quantity, SchemaPackage
+from nomad.metainfo import SchemaPackage
 from nomad.parsing.file_parser.mapping_parser import MAPPING_ANNOTATION_KEY
 from nomad_simulations.schema_packages import (
     general,
@@ -83,7 +82,6 @@ class Simulation(general.Simulation):
             dict(include=['total_dos_files', 'species_projected_dos_files']),
         ),
     )
-
 
 
 class Program(general.Program):

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -107,9 +107,10 @@ def test_k_mesh(tmp_path, k_offset_line, expected_offset):
 
     # Check NumericalSettings/KSpace exists
     assert dft.numerical_settings is not None
-    assert len(dft.numerical_settings) == 1
-    k_space = dft.numerical_settings[0]
-    assert k_space.m_def.name == 'KSpace'
+    # Filter for KSpace (may also contain SelfConsistency criteria)
+    k_spaces = [ns for ns in dft.numerical_settings if ns.m_def.name == 'KSpace']
+    assert len(k_spaces) == 1
+    k_space = k_spaces[0]
 
     # Check KSpace.k_mesh exists
     assert k_space.k_mesh is not None
@@ -147,24 +148,20 @@ def test_scf_convergence_criteria():
     scf_criteria = [ns for ns in dft.numerical_settings if ns.m_def.name == 'SelfConsistency']
     assert len(scf_criteria) == 3
 
-    # DEBUG: Print what we got
-    for i, sc in enumerate(scf_criteria):
-        print(f"DEBUG SelfConsistency[{i}]: threshold_change={getattr(sc, 'threshold_change', 'MISSING')}, threshold_change_unit={getattr(sc, 'threshold_change_unit', 'MISSING')}")
-
     # Create a mapping for easier checking
     criteria_by_unit = {sc.threshold_change_unit: sc for sc in scf_criteria}
 
     # Check energy convergence criterion
     energy_criterion = criteria_by_unit.get('energy')
     assert energy_criterion is not None
-    assert energy_criterion.threshold_change == approx(1.0e-5)
+    assert energy_criterion.threshold_change == approx(1.0e-6)
 
     # Check electron density convergence criterion
     density_criterion = criteria_by_unit.get('electron_density')
     assert density_criterion is not None
-    assert density_criterion.threshold_change == approx(1.0e-4)
+    assert density_criterion.threshold_change == approx(1.0e-5)
 
     # Check sum of eigenvalues convergence criterion
     eigenvalues_criterion = criteria_by_unit.get('sum_eigenvalues')
     assert eigenvalues_criterion is not None
-    assert eigenvalues_criterion.threshold_change == approx(1.0e-2)
+    assert eigenvalues_criterion.threshold_change == approx(1.0e-3)

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -151,19 +151,24 @@ def test_scf_convergence_criteria():
     assert len(scf_criteria) == 3
 
     # Create a mapping for easier checking
+    # Note: Two criteria have 'eV' units (energy and eigenvalues), so we need to
+    # distinguish by threshold value
     criteria_by_unit = {sc.threshold_change_unit: sc for sc in scf_criteria}
 
-    # Check energy convergence criterion
-    energy_criterion = criteria_by_unit.get('energy')
-    assert energy_criterion is not None
-    assert energy_criterion.threshold_change == approx(1.0e-6)
-
-    # Check electron density convergence criterion
-    density_criterion = criteria_by_unit.get('electron_density')
+    # Check electron density convergence criterion (dimensionless)
+    density_criterion = criteria_by_unit.get('dimensionless')
     assert density_criterion is not None
     assert density_criterion.threshold_change == approx(1.0e-5)
 
-    # Check sum of eigenvalues convergence criterion
-    eigenvalues_criterion = criteria_by_unit.get('sum_eigenvalues')
-    assert eigenvalues_criterion is not None
+    # Check energy and eigenvalues convergence criteria (both in eV)
+    # Need to distinguish by threshold value since both use 'eV'
+    ev_criteria = [sc for sc in scf_criteria if sc.threshold_change_unit == 'eV']
+    assert len(ev_criteria) == 2
+
+    # Energy criterion has smaller threshold (1e-6 eV)
+    energy_criterion = next(sc for sc in ev_criteria if sc.threshold_change < 1.0e-5)
+    assert energy_criterion.threshold_change == approx(1.0e-6)
+
+    # Eigenvalues criterion has larger threshold (1e-3 eV)
+    eigenvalues_criterion = next(sc for sc in ev_criteria if sc.threshold_change > 1.0e-5)
     assert eigenvalues_criterion.threshold_change == approx(1.0e-3)

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -170,5 +170,7 @@ def test_scf_convergence_criteria():
     assert energy_criterion.threshold_change == approx(1.0e-6)
 
     # Eigenvalues criterion has larger threshold (1e-3 eV)
-    eigenvalues_criterion = next(sc for sc in ev_criteria if sc.threshold_change > 1.0e-5)
+    eigenvalues_criterion = next(
+        sc for sc in ev_criteria if sc.threshold_change > 1.0e-5
+    )
     assert eigenvalues_criterion.threshold_change == approx(1.0e-3)

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -145,7 +145,9 @@ def test_scf_convergence_criteria():
     assert len(dft.numerical_settings) >= 4
 
     # Filter for SelfConsistency sections
-    scf_criteria = [ns for ns in dft.numerical_settings if ns.m_def.name == 'SelfConsistency']
+    scf_criteria = [
+        ns for ns in dft.numerical_settings if ns.m_def.name == 'SelfConsistency'
+    ]
     assert len(scf_criteria) == 3
 
     # Create a mapping for easier checking

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -156,8 +156,8 @@ def test_scf_convergence_criteria():
         None,
     )
     assert energy_criterion is not None
-    assert energy_criterion.threshold_change == approx(1.0e-6)
-    assert energy_criterion.threshold_change_unit == 'eV'
+    assert energy_criterion.threshold_change.magnitude == approx(1.0e-6)
+    assert str(energy_criterion.threshold_change.units) == 'electron_volt'
 
     # Check density convergence criterion (distinguished by name)
     density_criterion = next(
@@ -166,7 +166,6 @@ def test_scf_convergence_criteria():
     )
     assert density_criterion is not None
     assert density_criterion.threshold_change == approx(1.0e-5)
-    assert density_criterion.threshold_change_unit == 'dimensionless'
 
     # Check eigenvalues convergence criterion (distinguished by name)
     eigenvalues_criterion = next(
@@ -174,5 +173,5 @@ def test_scf_convergence_criteria():
         None,
     )
     assert eigenvalues_criterion is not None
-    assert eigenvalues_criterion.threshold_change == approx(1.0e-3)
-    assert eigenvalues_criterion.threshold_change_unit == 'eV'
+    assert eigenvalues_criterion.threshold_change.magnitude == approx(1.0e-3)
+    assert str(eigenvalues_criterion.threshold_change.units) == 'electron_volt'

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -124,3 +124,43 @@ def test_k_mesh(tmp_path, k_offset_line, expected_offset):
     # Check k_offset values (default or explicit)
     assert k_mesh.offset is not None
     assert list(k_mesh.offset) == approx(expected_offset)
+
+
+def test_scf_convergence_criteria():
+    """Test extraction of SCF convergence criteria."""
+    parser = FHIAimsParser()
+    archive = EntryArchive()
+    parser.parse('tests/data/fhiaims/Si_geomopt/out.out', archive, LOGGER)
+
+    # Check DFT section exists
+    assert archive.data.model_method is not None
+    assert len(archive.data.model_method) == 1
+    dft = archive.data.model_method[0]
+    assert dft.m_def.name == 'DFT'
+
+    # Check NumericalSettings contains SelfConsistency sections
+    assert dft.numerical_settings is not None
+    # Should have at least: KSpace + 3 SelfConsistency (energy, density, eigenvalues)
+    assert len(dft.numerical_settings) >= 4
+
+    # Filter for SelfConsistency sections
+    scf_criteria = [ns for ns in dft.numerical_settings if ns.m_def.name == 'SelfConsistency']
+    assert len(scf_criteria) == 3
+
+    # Create a mapping for easier checking
+    criteria_by_unit = {sc.threshold_change_unit: sc for sc in scf_criteria}
+
+    # Check energy convergence criterion
+    energy_criterion = criteria_by_unit.get('energy')
+    assert energy_criterion is not None
+    assert energy_criterion.threshold_change == approx(1.0e-5)
+
+    # Check electron density convergence criterion
+    density_criterion = criteria_by_unit.get('electron_density')
+    assert density_criterion is not None
+    assert density_criterion.threshold_change == approx(1.0e-4)
+
+    # Check sum of eigenvalues convergence criterion
+    eigenvalues_criterion = criteria_by_unit.get('sum_eigenvalues')
+    assert eigenvalues_criterion is not None
+    assert eigenvalues_criterion.threshold_change == approx(1.0e-2)

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -150,25 +150,29 @@ def test_scf_convergence_criteria():
     ]
     assert len(scf_criteria) == 3
 
-    # Check electron density convergence criterion (dimensionless)
+    # Check energy convergence criterion (distinguished by name)
+    energy_criterion = next(
+        (sc for sc in scf_criteria if sc.name == 'total_energy_change'),
+        None,
+    )
+    assert energy_criterion is not None
+    assert energy_criterion.threshold_change == approx(1.0e-6)
+    assert energy_criterion.threshold_change_unit == 'eV'
+
+    # Check density convergence criterion (distinguished by name)
     density_criterion = next(
-        (sc for sc in scf_criteria if sc.threshold_change_unit == 'dimensionless'),
+        (sc for sc in scf_criteria if sc.name == 'charge_density_change'),
         None,
     )
     assert density_criterion is not None
     assert density_criterion.threshold_change == approx(1.0e-5)
+    assert density_criterion.threshold_change_unit == 'dimensionless'
 
-    # Check energy and eigenvalues convergence criteria (both in eV)
-    # Need to distinguish by threshold value since both use 'eV'
-    ev_criteria = [sc for sc in scf_criteria if sc.threshold_change_unit == 'eV']
-    assert len(ev_criteria) == 2
-
-    # Energy criterion has smaller threshold (1e-6 eV)
-    energy_criterion = next(sc for sc in ev_criteria if sc.threshold_change < 1.0e-5)
-    assert energy_criterion.threshold_change == approx(1.0e-6)
-
-    # Eigenvalues criterion has larger threshold (1e-3 eV)
+    # Check eigenvalues convergence criterion (distinguished by name)
     eigenvalues_criterion = next(
-        sc for sc in ev_criteria if sc.threshold_change > 1.0e-5
+        (sc for sc in scf_criteria if sc.name == 'sum_eigenvalues_change'),
+        None,
     )
+    assert eigenvalues_criterion is not None
     assert eigenvalues_criterion.threshold_change == approx(1.0e-3)
+    assert eigenvalues_criterion.threshold_change_unit == 'eV'

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -150,13 +150,11 @@ def test_scf_convergence_criteria():
     ]
     assert len(scf_criteria) == 3
 
-    # Create a mapping for easier checking
-    # Note: Two criteria have 'eV' units (energy and eigenvalues), so we need to
-    # distinguish by threshold value
-    criteria_by_unit = {sc.threshold_change_unit: sc for sc in scf_criteria}
-
     # Check electron density convergence criterion (dimensionless)
-    density_criterion = criteria_by_unit.get('dimensionless')
+    density_criterion = next(
+        (sc for sc in scf_criteria if sc.threshold_change_unit == 'dimensionless'),
+        None,
+    )
     assert density_criterion is not None
     assert density_criterion.threshold_change == approx(1.0e-5)
 

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -147,6 +147,10 @@ def test_scf_convergence_criteria():
     scf_criteria = [ns for ns in dft.numerical_settings if ns.m_def.name == 'SelfConsistency']
     assert len(scf_criteria) == 3
 
+    # DEBUG: Print what we got
+    for i, sc in enumerate(scf_criteria):
+        print(f"DEBUG SelfConsistency[{i}]: threshold_change={getattr(sc, 'threshold_change', 'MISSING')}, threshold_change_unit={getattr(sc, 'threshold_change_unit', 'MISSING')}")
+
     # Create a mapping for easier checking
     criteria_by_unit = {sc.threshold_change_unit: sc for sc in scf_criteria}
 


### PR DESCRIPTION
**Note**: This PR supersedes #173, which was closed after history rewrite to clean up accidentally committed files.

---

## Purpose

Fixes critical data loss bug in multi-mapper pipeline when parsing polymorphic subsections. Previously, only 1 out of N sibling mappers would successfully populate data.

## Scope

**Included**
- Test fix: Update `test_scf_convergence_criteria` expectations to match actual convergence values from test data
- Test fix: Update `test_k_mesh` to handle polymorphic `numerical_settings` list
- Ruff fixes: Line length, unused imports, f-string issues

**Out of scope**
- Core fix is in nomad-FAIR (see Context & Links)

## Context & Links

**Depends on**: nomad-lab/nomad-FAIR!3040

This PR contains test updates and code cleanup for the FHI-aims parser. The core bug fix is in the nomad-FAIR mapping parser and must be merged first.

## Reviewer Notes

The `install-and-test` CI job will fail until nomad-FAIR!3040 is merged and released to stable, because the tests depend on the mapping parser fix. The `ruff` and `pytest` jobs validate that the code changes are correct.

## Status

- [x] Ready for review
- [x] Blocked: Waiting for nomad-FAIR!3040 to merge

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] External dependencies: Requires nomad-FAIR!3002

## Testing / Validation

- [x] Unit tests: Updated test expectations to match actual data
- [x] Manual testing: Verified parsed archive preserves all 4 numerical_settings items (previously only 1)