### PR TITLE
Pin nmr schema version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab>=1.3.16.dev100",
     "nomad-simulations@git+https://github.com/nomad-coe/nomad-simulations.git@develop",
-    "nomad-nmr-schema@git+https://github.com/FAIRmat-NFDI/nomad-schema-plugin-nmr@v0.1.2",
+    "nomad-nmr-schema@git+https://github.com/FAIRmat-NFDI/nomad-schema-plugin-nmr@v0.1.4",
     "python-magic-bin; sys_platform == 'win32'",
     "phonopy>=2.35",
     "mdanalysis>=2.8.0,<3.0.0 ; python_full_version >= '3.10'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab>=1.3.16.dev100",
     "nomad-simulations@git+https://github.com/nomad-coe/nomad-simulations.git@develop",
-    "nomad-nmr-schema@git+https://github.com/FAIRmat-NFDI/nomad-schema-plugin-nmr@main",
+    "nomad-nmr-schema@git+https://github.com/FAIRmat-NFDI/nomad-schema-plugin-nmr@v0.1.2",
     "python-magic-bin; sys_platform == 'win32'",
     "phonopy>=2.35",
     "mdanalysis>=2.8.0,<3.0.0 ; python_full_version >= '3.10'",


### PR DESCRIPTION
In order to avoid uncontrolled problems with the test-oasis deployment, we should pin the nmr schema version.