### PR TITLE
Re-enable FHI-aims total energy mapping

### DIFF
--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -132,9 +132,9 @@ class AtomsState(model_system.AtomsState):
 
 
 class Outputs(outputs.Outputs):
-    # outputs.Outputs.total_energies.m_annotations.setdefault(
-    #     MAPPING_ANNOTATION_KEY, {}
-    # ).update(dict(text=Mapper(mapper=('get_energies', ['.@']))))
+    add_mapping_annotation(
+        outputs.Outputs.total_energies, TEXT_KEY, ('get_energies', ['.@'])
+    )
     outputs.Outputs.total_forces.m_annotations.setdefault(
         MAPPING_ANNOTATION_KEY, {}
     ).update(dict(text=Mapper(mapper=('get_forces', ['.@']))))

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -175,3 +175,52 @@ def test_scf_convergence_criteria():
     assert eigenvalues_criterion is not None
     assert eigenvalues_criterion.threshold_change.magnitude == approx(1.0e-3)
     assert str(eigenvalues_criterion.threshold_change.units) == 'electron_volt'
+
+
+def test_total_energies():
+    """Test that total energies are extracted and mapped correctly."""
+    parser = FHIAimsParser()
+    archive = EntryArchive()
+    parser.parse('tests/data/fhiaims/Si_geomopt/out.out', archive, LOGGER)
+
+    # Check outputs exist
+    outputs = archive.data.outputs
+    assert outputs is not None
+    assert len(outputs) == 5  # Geometry optimization has 5 steps
+
+    # Check each output has total_energies
+    for i, output in enumerate(outputs):
+        assert output.total_energies is not None, f'Output {i} has no total_energies'
+        assert len(output.total_energies) == 1, f'Output {i} should have exactly 1 total_energy'
+
+        total_energy = output.total_energies[0]
+
+        # Check that energy value exists and is a Quantity
+        assert total_energy.value is not None, f'Output {i} total_energy has no value'
+        assert hasattr(total_energy.value, 'magnitude'), f'Output {i} energy value is not a Quantity'
+
+        # Energy should be negative for this Si system
+        energy_ev = total_energy.value.to('eV').magnitude
+        assert energy_ev < 0, f'Output {i} energy should be negative, got {energy_ev}'
+
+        # Check energy is in reasonable range for Si (around -15696 eV for 2 atoms)
+        assert -16000 < energy_ev < -15600, f'Output {i} energy {energy_ev} eV out of expected range'
+
+        # Check that contributions/components exist
+        assert total_energy.contributions is not None, f'Output {i} has no energy contributions'
+        assert len(total_energy.contributions) > 0, f'Output {i} should have energy contributions'
+
+    # Explicitly check first step energy value (from test data analysis)
+    # First output (index 0) should have "Total energy uncorrected" from compact form
+    # which is -15696.1246183848 eV
+    first_energy = outputs[0].total_energies[0].value.to('eV').magnitude
+    assert first_energy == approx(-15696.1246183848, abs=0.01)
+
+    # Check that energy contributions have names and values
+    first_contributions = outputs[0].total_energies[0].contributions
+    assert any('eigenvalues' in contrib.name.lower() for contrib in first_contributions if contrib.name), \
+        'Should have eigenvalues contribution'
+
+    # All contributions should have a value
+    for contrib in first_contributions:
+        assert contrib.value is not None, f'Contribution {contrib.name} has no value'

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -191,35 +191,49 @@ def test_total_energies():
     # Check each output has total_energies
     for i, output in enumerate(outputs):
         assert output.total_energies is not None, f'Output {i} has no total_energies'
-        assert len(output.total_energies) == 1, f'Output {i} should have exactly 1 total_energy'
+        assert len(output.total_energies) == 1, (
+            f'Output {i} should have exactly 1 total_energy'
+        )
 
         total_energy = output.total_energies[0]
 
         # Check that energy value exists and is a Quantity
         assert total_energy.value is not None, f'Output {i} total_energy has no value'
-        assert hasattr(total_energy.value, 'magnitude'), f'Output {i} energy value is not a Quantity'
+        assert hasattr(total_energy.value, 'magnitude'), (
+            f'Output {i} energy value is not a Quantity'
+        )
 
         # Energy should be negative for this Si system
         energy_ev = total_energy.value.to('eV').magnitude
         assert energy_ev < 0, f'Output {i} energy should be negative, got {energy_ev}'
 
-        # Check energy is in reasonable range for Si (around -15696 eV for 2 atoms)
-        assert -16000 < energy_ev < -15600, f'Output {i} energy {energy_ev} eV out of expected range'
+        # Check energy is in reasonable range for Si (~-15696 eV for 2 atoms)
+        assert -16000 < energy_ev < -15600, (
+            f'Output {i} energy {energy_ev} eV out of expected range'
+        )
 
         # Check that contributions/components exist
-        assert total_energy.contributions is not None, f'Output {i} has no energy contributions'
-        assert len(total_energy.contributions) > 0, f'Output {i} should have energy contributions'
+        assert total_energy.contributions is not None, (
+            f'Output {i} has no energy contributions'
+        )
+        assert len(total_energy.contributions) > 0, (
+            f'Output {i} should have energy contributions'
+        )
 
     # Explicitly check first step energy value (from test data analysis)
-    # First output (index 0) should have "Total energy uncorrected" from compact form
+    # First output should have "Total energy uncorrected" from compact form
     # which is -15696.1246183848 eV
     first_energy = outputs[0].total_energies[0].value.to('eV').magnitude
     assert first_energy == approx(-15696.1246183848, abs=0.01)
 
     # Check that energy contributions have names and values
     first_contributions = outputs[0].total_energies[0].contributions
-    assert any('eigenvalues' in contrib.name.lower() for contrib in first_contributions if contrib.name), \
-        'Should have eigenvalues contribution'
+    has_eigenvalues = any(
+        'eigenvalues' in contrib.name.lower()
+        for contrib in first_contributions
+        if contrib.name
+    )
+    assert has_eigenvalues, 'Should have eigenvalues contribution'
 
     # All contributions should have a value
     for contrib in first_contributions:


### PR DESCRIPTION
## Purpose
Re-enables the `total_energies` mapping for FHI-aims parser that was disabled in commit 0e00561 (PR #150, March 2026). The parser's `get_energies()` method has remained functional - only the schema mapping annotation was commented out.

## Scope

**Included**
- Re-enable `total_energies` mapping annotation in `fhiaims.py`
- Add comprehensive test coverage for energy extraction
- Validate energy values and contributions structure

**Out of scope**
- XC functional mappings (also commented out in #150, but not needed for this fix)
- Duplicate annotation cleanup (lines 138-157 have redundant force/eigenvalue annotations)
- Integration with PR #170 (large-scale electronic properties migration)

## Context & Links

**Why it was disabled**: During the convergence targets migration (#150), the energy mapping was intentionally commented out using the old `m_annotations.setdefault()` syntax. The commit message stated: "Future migration to dict-based `m_def` mapping annotations should be tracked separately (see PR #162 for reference)."

**Related PRs**:
- #150 - Original PR that commented out energy mapping (merged March 2026)
- #170 - Large electronic properties migration (open, includes FHI-aims + 17 other parsers)
- #176 - Backup branch of FHI-aims changes from #170
- #177 - SCF convergence criteria extraction (merged May 2026)

**Investigation notes**: See `.investigation-notes.md` in branch (not committed) for detailed impact analysis.

## Reviewer Notes

**Key changes**:
1. Replace commented `m_annotations.setdefault()` with active `add_mapping_annotation()` for consistency with other parsers (VASP, GPAW, QE all use this pattern)
2. New test `test_total_energies()` validates:
   - Energy extraction across all 5 geometry optimization steps
   - Correct energy value (-15696.12 eV for first step)
   - Energy contributions/components structure
   - Pint Quantity handling

**Risk assessment**: LOW
- Parser method `get_energies()` already works (parser.py:289-301)
- MD parser utils are defensive (check if `total_energies` is empty before appending)
- No existing tests affected (no prior energy tests)
- Follows established pattern from 10+ other parsers

## Status

- [x] Ready for review

## Breaking Changes

- [ ] None

## Dependencies / Blockers

- [ ] None
- Independent of PR #170 (that PR re-enables energies too, but for all parsers)
- Can be merged before or after #170 without conflict

## Testing / Validation

- [x] Unit tests: Added `test_total_energies()` with comprehensive validation
- [x] All FHI-aims tests pass (7/7)
- [x] Energy values match test data analysis
- [x] Energy contributions properly structured