### PR TITLE
Remove polyfill.io from MkDocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,5 +71,4 @@ extra_css:
   - stylesheets/extra.css
 extra_javascript:
   - javascript.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
This PR removes the polyfill.io script reference from MkDocs configuration.

polyfill.io should no longer be used as an external dependency.

See: https://github.com/FAIRmat-NFDI/nomad-docs/pull/228