### PR TITLE
Parser data-loss corrections from PR 170 migration verification

### DIFF
--- a/src/nomad_simulation_parsers/parsers/gpaw/parser.py
+++ b/src/nomad_simulation_parsers/parsers/gpaw/parser.py
@@ -23,6 +23,10 @@ from .gpw_parser import GPWFileParser
 
 LOGGER = get_logger(__name__)
 
+# Constants for array dimensionality checks
+NDIM_NON_SPIN_POLARIZED = 2  # Shape: [n_kpoints, n_bands]
+N_SPIN_CHANNELS = 2  # Number of spin channels for spin-polarized calculations
+
 
 class GPWParser(MappingParser):
     file_parser = GPWFileParser()
@@ -81,16 +85,38 @@ class GPWParser(MappingParser):
             self.file_parser.parser.get_array('eigenvalues'), 'energyunit'
         )
         occupations = self.file_parser.parser.get_array('occupation')
-        kpoints = self.file_parser.parser.get_array('kpoints')
-        return [
-            dict(
-                eigenvalues=eigenvalue,
-                occupations=occupations[n],
-                kpoints=kpoints,
+
+        if eigenvalues is None or occupations is None:
+            return []
+
+        # eigenvalues and occupations should have shape [n_spin, n_kpoints, n_bands]
+        # or [n_kpoints, n_bands] for non-spin-polarized
+        if eigenvalues.ndim == NDIM_NON_SPIN_POLARIZED:
+            # Non-spin-polarized: reshape to add spin dimension
+            eigenvalues = eigenvalues[np.newaxis, :, :]
+            occupations = occupations[np.newaxis, :, :]
+
+        n_spin = eigenvalues.shape[0]
+        n_bands = (
+            eigenvalues.shape[2]
+            if eigenvalues.ndim > NDIM_NON_SPIN_POLARIZED
+            else eigenvalues.shape[1]
+        )
+
+        data = []
+        for spin_idx in range(n_spin):
+            entry = dict(
+                value=eigenvalues[spin_idx],  # 2D: [n_kpoints, n_bands]
+                occupation=occupations[spin_idx],  # 2D: [n_kpoints, n_bands]
+                n_levels=n_bands,
                 highest_occupied=reference_energy,
             )
-            for n, eigenvalue in enumerate(eigenvalues)
-        ]
+            # Only add spin_channel if there are multiple spins
+            if n_spin == N_SPIN_CHANNELS:
+                entry['spin_channel'] = spin_idx
+            data.append(entry)
+
+        return data
 
     def get_reference_energy(self):
         fermi_level = self.file_parser.parser.get_parameter('fermilevel')
@@ -132,8 +158,8 @@ class GPWParser(MappingParser):
         """Calculate band gaps from eigenvalues using common utility."""
         band_gaps = []
         for spin_channel, eigenvalue_data in enumerate(self.get_eigenvalues()):
-            energies = eigenvalue_data.get('eigenvalues')
-            occupations = eigenvalue_data.get('occupations')
+            energies = eigenvalue_data.get('value')
+            occupations = eigenvalue_data.get('occupation')
 
             # Use common utility for band gap calculation (handles units automatically)
             gap_result = calculate_band_gap_from_occupations(

--- a/src/nomad_simulation_parsers/parsers/octopus/parser.py
+++ b/src/nomad_simulation_parsers/parsers/octopus/parser.py
@@ -294,13 +294,13 @@ class OctopusMainfileParser(TextParser):
             return self._initial_system
 
         self._initial_system = {}
+        atoms = None  # Initialize atoms to None for all paths
         symbols, coordinates = self.log_parser.get_coordinates()
         if len(coordinates) == 0:
             # get if from inp
             symbols, coordinates = self.inp_parser.get_coordinates()
         if len(coordinates) == 0:
             # try to read from file
-            atoms = None
             file_types = {
                 'PDBCoordinates': ['proteindatabank'],
                 'XYZCoordinates': ['extxyz', 'xyz'],
@@ -363,22 +363,54 @@ class OctopusMainfileParser(TextParser):
         self._initial_system['labels'] = symbols
         return self._initial_system
 
-    def get_systems(self, minimization: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        systems = [self.initial_system]
+    def get_systems(
+        self, source: dict[str, Any] | list[dict[str, Any]] | None = None
+    ) -> list[dict[str, Any]]:
+        # Always include initial system, even for static calculations
+        initial = self.initial_system
+        if not initial:
+            return []
+
+        systems = [initial]
+
+        # Extract minimization data from source (dict or list)
+        minimization = None
+        if isinstance(source, dict):
+            minimization = source.get('minimization')
+        elif isinstance(source, list):
+            minimization = source
+
+        # Add geometry optimization steps if present
         for mini in minimization or []:
             number = mini.get('numbr')
             if number is None:
                 continue
             path = os.path.join(self._maindir, f'geom/go.{number:04d}.xyz')
-            atoms = read(path, format='xyz')
-            systems.append(
-                dict(
-                    positions=atoms.get_positions() * ureg.angstrom,
-                    labels=atoms.get_chemical_symbols(),
-                    pbc=systems[0].get('pbc'),
+            try:
+                atoms = read(path, format='xyz')
+                systems.append(
+                    dict(
+                        positions=atoms.get_positions() * ureg.angstrom,
+                        labels=atoms.get_chemical_symbols(),
+                        pbc=systems[0].get('pbc'),
+                    )
                 )
-            )
+            except Exception as e:
+                self.logger.warning(
+                    'Could not read geometry optimization step',
+                    data=dict(path=path, error=str(e)),
+                )
         return systems
+
+    def get_initial_system_for_mapping(
+        self, source: Any = None
+    ) -> dict[str, Any] | None:
+        """Always return the initial system, regardless of source data.
+
+        This ensures model_system is populated even for static calculations
+        without minimization data.
+        """
+        return self.initial_system
 
     def get_outputs(self, sources: list[dict[str]]) -> list[dict[str, Any]]:
         outputs = []
@@ -490,6 +522,15 @@ class OctopusArchiveWriter(ArchiveWriter):
 
         self.archive_parser.data_object = self.archive.data
         self.archive_parser.annotation_key = octopus.OUT_KEY
+
+        # Ensure initial_system data is available for mapping
+        # even if no minimization or time-dependent data exists
+        # Access the underlying text parser's data dict
+        if not self.mainfile_parser.text_parser.data:
+            self.mainfile_parser.text_parser.data = {}
+        self.mainfile_parser.text_parser.data[
+            '_initial_system'
+        ] = self.mainfile_parser.initial_system
 
         self.mainfile_parser.convert(self.archive_parser)
 

--- a/src/nomad_simulation_parsers/parsers/quantumespresso/pwscf/parser.py
+++ b/src/nomad_simulation_parsers/parsers/quantumespresso/pwscf/parser.py
@@ -86,16 +86,18 @@ class PWSCFMainfileTextParser(MainfileTextParser):
                     ).astype(float)
         return results
 
+    _configuration_methods = {
+        'self_consistent': 'single_point',
+        'bandstructure': 'single_point',
+        'bfgs_geometry_optimization': 'geometry_optimization',
+        'molecular_dynamics': 'molecular_dynamics',
+        'langevin_dynamics': 'langevin_dynamics',
+        'damped_dynamics': 'geometry_optimization',
+        'vcs_wentzcovitch_damped_minimization': 'geometry_optimization',
+    }
+
     def get_configurations(self, source: dict[str, Any]) -> list[dict[str, Any]]:
-        methods = {
-            'self_consistent': 'single_point',
-            'bandstructure': 'single_point',
-            'bfgs_geometry_optimization': 'geometry_optimization',
-            'molecular_dynamics': 'molecular_dynamics',
-            'langevin_dynamics': 'langevin_dynamics',
-            'damped_dynamics': 'geometry_optimization',
-            'vcs_wentzcovitch_damped_minimization': 'geometry_optimization',
-        }
+        methods = self._configuration_methods
 
         configurations = []
         header = source.get('header', {}) if isinstance(source, dict) else {}
@@ -138,6 +140,33 @@ class PWSCFMainfileTextParser(MainfileTextParser):
 
             configurations.append(sec)
         return configurations
+
+    def get_configuration_forces(self, source: dict[str, Any]) -> list[list[Any]]:
+        """Per-configuration force series, index-aligned with get_configurations.
+
+        Multi-step runs (geometry optimization, molecular dynamics) carry one
+        force array per SCF step; single-point configurations yield an empty
+        series since their forces are covered by the step-resolved outputs.
+        """
+        forces = []
+        for key in self._configuration_methods:
+            config = source.get(key)
+            if config is None:
+                continue
+            sc_config = config.get('self_consistent', config)
+            if isinstance(sc_config, list):
+                if not sc_config:
+                    continue
+                forces.append(
+                    [
+                        step.get('forces')
+                        for step in sc_config
+                        if hasattr(step, 'get') and step.get('forces') is not None
+                    ]
+                )
+            else:
+                forces.append([])
+        return forces
 
     def _resolve_scf_source(self, source: Any) -> Any:
         if isinstance(source, list):
@@ -490,6 +519,22 @@ class PWSCFArchiveWriter(QuantumEspressoArchiveWriter):
                     for dos in output.electronic_dos:
                         if dos.energies_origin is None:
                             dos.energies_origin = reference_energy
+
+        # TODO(mapping-migration): remove this parser-side forces fallback once
+        # per-step force payloads can be expressed via mapping annotations.
+        # `Outputs.total_forces` maps '.@', which lost the step-resolved forces
+        # when `get_configurations` started returning only the final SCF step.
+        if hasattr(self.mainfile_parser, 'get_configuration_forces'):
+            configuration_forces = self.mainfile_parser.get_configuration_forces(
+                self.mainfile_parser.data
+            )
+            for i, output in enumerate(archive.data.outputs):
+                if output.total_forces or i >= len(configuration_forces):
+                    continue
+                output.total_forces = [
+                    simulation_outputs.TotalForce(value=value)
+                    for value in configuration_forces[i]
+                ]
 
         dos_files = search_files(
             pattern='*.dos', basedir=os.path.dirname(self.mainfile)

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -437,10 +437,9 @@ class OutcarParser(MappingTextParser):
         for nspin in range(ispin):
             eigs, occs = eigenvalues[nspin].T[1:3]
             entry = dict(
-                eigenvalues=eigs.T,
-                occupations=occs.T,
-                n_bands=n_bands,
-                npoints=n_kpts,
+                value=eigs.T,
+                occupation=occs.T,
+                n_levels=n_bands,
             )
             if ispin == N_SPIN_CHANNELS:
                 entry['spin_channel'] = nspin
@@ -469,8 +468,8 @@ class OutcarParser(MappingTextParser):
         """Calculate band gaps from eigenvalues using common utility."""
         band_gaps = []
         for eig in self.get_eigenvalues(eigenvalues, parameters):
-            values = eig.get('eigenvalues')
-            occupations = eig.get('occupations')
+            values = eig.get('value')
+            occupations = eig.get('occupation')
             spin_channel = eig.get('spin_channel')
 
             # Use common utility for band gap calculation

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -142,10 +142,9 @@ class VasprunParser(XMLParser):
             eigs = data[:, :, 0]
             occs = data[:, :, 1]
             entry = dict(
-                eigenvalues=eigs,
-                occupations=occs,
-                n_bands=eigs.shape[1],
-                npoints=eigs.shape[0],
+                value=eigs,
+                occupation=occs,
+                n_levels=eigs.shape[1],
             )
             if is_spin_polarized:
                 entry['spin_channel'] = spin_channel
@@ -171,8 +170,8 @@ class VasprunParser(XMLParser):
         """Calculate band gaps from eigenvalues using common utility."""
         result = []
         for eigenvalues in self.get_eigenvalues(source):
-            eigs = eigenvalues.get('eigenvalues')
-            occs = eigenvalues.get('occupations')
+            eigs = eigenvalues.get('value')
+            occs = eigenvalues.get('occupation')
             spin_channel = eigenvalues.get('spin_channel')
 
             # Use common utility for band gap calculation

--- a/src/nomad_simulation_parsers/schema_packages/gpaw.py
+++ b/src/nomad_simulation_parsers/schema_packages/gpaw.py
@@ -66,9 +66,12 @@ class TotalForce(outputs.TotalForce):
 
 
 class ElectronicEigenvalues(outputs.ElectronicEigenvalues):
-    add_mapping_annotation(outputs.ElectronicEigenvalues.value, GPW_KEY, '.eigenvalues')
+    add_mapping_annotation(outputs.ElectronicEigenvalues.value, GPW_KEY, '.value')
     add_mapping_annotation(
-        outputs.ElectronicEigenvalues.occupation, GPW_KEY, '.occupations'
+        outputs.ElectronicEigenvalues.occupation, GPW_KEY, '.occupation'
+    )
+    add_mapping_annotation(
+        outputs.ElectronicEigenvalues.n_levels, GPW_KEY, '.n_levels'
     )
     add_mapping_annotation(
         outputs.ElectronicEigenvalues.highest_occupied,

--- a/src/nomad_simulation_parsers/schema_packages/octopus.py
+++ b/src/nomad_simulation_parsers/schema_packages/octopus.py
@@ -159,6 +159,11 @@ class Simulation(general.Simulation):
         general.Simulation.program, OUT_KEY, ('get_header', ['.header'])
     )
     add_mapping_annotation(model_method.DFT.m_def, OUT_KEY, '.@')
+    # Map model_system: _initial_system is always present (added in write_to_archive)
+    # get_systems also handles minimization steps if present
+    add_mapping_annotation(
+        general.Simulation.model_system, OUT_KEY, '._initial_system'
+    )
     add_mapping_annotation(
         general.Simulation.model_system, OUT_KEY, ('get_systems', ['.minimization'])
     )

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -143,21 +143,13 @@ class SelfConsistency(numerical_settings.SelfConsistency):
             'modeling.parameters.separator[?"@name"==\'electronic\'] '
             '| [0].i[?"@name"==\'EDIFF\'] | [0].__value'
         ),
+        unit='eV',
     )
     add_mapping_annotation(
         numerical_settings.SelfConsistency.threshold_change,
         OUTCAR_KEY,
         'parameters.EDIFF',
-    )
-    add_mapping_annotation(
-        numerical_settings.SelfConsistency.threshold_change_unit,
-        XML_KEY,
-        ('get_ediff_unit', []),
-    )
-    add_mapping_annotation(
-        numerical_settings.SelfConsistency.threshold_change_unit,
-        OUTCAR_KEY,
-        ('get_ediff_unit', []),
+        unit='eV',
     )
 
 
@@ -276,21 +268,6 @@ class Outputs(outputs.Outputs):
     )
     add_mapping_annotation(
         outputs.Outputs.scf_steps, OUTCAR_KEY, ('get_scf_steps', ['.@'])
-    )
-    add_mapping_annotation(
-        outputs.Outputs.electronic_band_structures,
-        XML_KEY,
-        ('get_band_structures', ['.eigenvalues']),
-    )
-    add_mapping_annotation(
-        outputs.Outputs.electronic_band_structures,
-        XML2_KEY,
-        ('get_band_structures', ['.eigenvalues']),
-    )
-    add_mapping_annotation(
-        outputs.Outputs.electronic_band_structures,
-        OUTCAR_KEY,
-        ('get_band_structures', ['.eigenvalues', 'parameters']),
     )
     add_mapping_annotation(
         outputs.Outputs.electronic_band_gaps,

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -36,12 +36,13 @@ def test_vasprun_system_and_electronic_outputs():
     assert sec_system.particle_states[0].chemical_symbol == 'Ac'
 
     sec_output = archive.data.outputs[0]
-    assert len(sec_output.electronic_band_structures) > 0
+    assert len(sec_output.electronic_eigenvalues) > 0
     assert len(sec_output.electronic_band_gaps) > 0
     assert len(sec_output.electronic_dos) > 0
 
-    sec_band_structure = sec_output.electronic_band_structures[0]
-    assert sec_band_structure.value is not None
+    sec_eigenvalues = sec_output.electronic_eigenvalues[0]
+    assert sec_eigenvalues.value is not None
+    assert sec_eigenvalues.occupation is not None
 
     sec_band_gap = sec_output.electronic_band_gaps[0]
     assert sec_band_gap.value is not None
@@ -70,10 +71,11 @@ def test_outcar_electronic_outputs_from_doscar_and_eigenvalues():
     assert len(outputs) > 0
     output = outputs[0]
 
-    assert output.electronic_band_structures is not None
-    assert len(output.electronic_band_structures) > 0
-    band_structure = output.electronic_band_structures[0]
-    assert band_structure.value is not None
+    assert output.electronic_eigenvalues is not None
+    assert len(output.electronic_eigenvalues) > 0
+    eigenvalues = output.electronic_eigenvalues[0]
+    assert eigenvalues.value is not None
+    assert eigenvalues.occupation is not None
 
     if output.electronic_band_gaps:
         assert output.electronic_band_gaps[0].value is not None
@@ -157,7 +159,7 @@ def test_vasprun_backfills_electronic_outputs_from_outcar_when_xml_missing():
         archive = _parse(str(Path(tmpdir) / 'vasprun.xml'))
         output = archive.data.outputs[0]
 
-        assert output.electronic_band_structures is not None
-        assert len(output.electronic_band_structures) > 0
+        assert output.electronic_eigenvalues is not None
+        assert len(output.electronic_eigenvalues) > 0
         assert output.electronic_dos is not None
         assert len(output.electronic_dos) > 0


### PR DESCRIPTION
## Purpose
Snapshot-based verification of the PR #170 migration (comparing parser output against a pre-migration baseline at 1c7acd6) surfaced data that the migrated parsers no longer extract. This PR restores that data and fixes related schema mapping errors, so the migration is strictly additive.

## Scope

**Included**

- GPAW: eigenvalues extraction with schema-conformant field names (`value`, `occupation`, `n_levels`), non-spin-polarized handling
- Octopus: `model_system` population for static calculations; defensive reading of geometry optimization steps
- VASP: `SelfConsistency.threshold_change` AttributeError fix (`unit='eV'` instead of non-existent `threshold_change_unit`); revert to `electronic_eigenvalues` output
- Quantum Espresso: restore per-step `total_forces` for multi-step runs, lost when `get_configurations` moved to final-SCF-step selection

**Out of scope**

- The snapshot test infrastructure used to find these regressions (separate branch `test/pr170-syrupy-verification`)
- Framework-level ordering determinism fix (nomad-FAIR MR 3103)

## Context & Links

- Stacks onto #170 (base: `test-data-normalization`)
- Related: https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/3103 (polymorphic sub-section ordering was nondeterministic per process; only affects order, not content)

## Reviewer Notes

The QE forces restoration uses a writer-side fallback rather than mapping annotations; mapping-driven payload injection does not reach `archive.data` (documented with TODO(mapping-migration) markers, same pattern as the existing electronic-properties fallback).

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] Unit tests
- [x] Integration tests (full suite: 176 passed, 8 skipped; ruff clean)
- [x] Manual testing (explain): snapshot comparison against pre-migration baseline reports zero removals; restored QE force values match baseline exactly