### PR TITLE
Parse the VASP DFT exchange-correlation functional and Jacob's ladder

### DIFF
--- a/docs/explanation/xc-functionals.md
+++ b/docs/explanation/xc-functionals.md
@@ -1,0 +1,146 @@
+# Exchange–correlation functionals
+
+## Overview
+
+Every DFT code records the exchange–correlation (XC) functional in its own way —
+an input tag, an integer code, or a human-readable line in the output — and only
+rarely as a single canonical name. The simulation parsers reduce that variety to
+one of two forms that the `nomad-simulations` schema understands, and leave the
+[LibXC](https://libxc.gitlab.io/functionals/) taxonomy (family, kind, and the
+derived Jacob's ladder rung) to the schema rather than reconstructing it per
+parser.
+
+A parser produces either:
+
+- a **canonical name** in `XCFunctional.functional_key` — used when the code
+  names the functional, or when its tags reduce cleanly to a standard name
+  (`PBE`, `HSE06`, `B3LYP5`, …). The schema's alias table
+  (`nomad_simulations/.../libxc/aliases.json`) expands the name into LibXC
+  components; or
+- **free-form components** in `XCFunctional.components` — used when the code
+  reports the exchange and correlation parts individually (as LibXC labels or
+  ids). The schema resolves each component from the LibXC registry, filling its
+  family and kind.
+
+The choice reflects what the code actually reports: a name where one exists, the
+raw parts otherwise. Either way the parser never hard-codes LibXC family/kind
+data. A component that the registry cannot resolve is retained and flagged
+`unidentified` instead of being dropped, so a functional's composition is never
+silently misrepresented as complete.
+
+This page explains the non-obvious conventions behind each code's mapping. It is
+deliberately not an exhaustive list of supported functionals — the maps in the
+parser sources are authoritative for that. It focuses on the setups where the
+code's XC specification is indirect or easy to misread.
+
+## How each code expresses XC
+
+### ABINIT
+
+ABINIT identifies XC by the single integer `ixc`. A non-negative `ixc` selects a
+built-in preset (`1` = Teter93 LDA, `11` = PBE, `14` = revPBE, `15` = RPBE,
+`23` = Wu–Cohen, …), mapped through a small table. A **negative** `ixc` packs two
+LibXC functional ids positionally as `-(1000·id_x + id_c)` — for example
+`ixc = -101130` is LibXC `101` (`XC_GGA_X_PBE`) plus `130` (`XC_GGA_C_PBE`),
+i.e. PBE. The parser emits those ids as components and lets the schema registry
+resolve them, which also covers ids the local table does not list.
+
+### AMS / ADF
+
+AMS reports the active functional per Jacob's-ladder rung in its density-functional
+block (`LDA:`, `Gradient Corrections:`, `Meta-GGA:`). The highest present rung is
+the functional in effect. A two-word gradient-correction entry names the exchange
+and correlation authors together (`Becke Perdew` = BP86).
+
+### CRYSTAL
+
+CRYSTAL names the exchange and correlation keywords separately (`BECKE`, `PZ`,
+`PBE`, `PWGGA`, …); the parser maps each keyword to its LibXC label(s) and lets
+the schema assemble the functional.
+
+### exciting
+
+exciting's INFO file gives an integer `xctype` code that the parser maps to LibXC
+labels; the XML output gives LibXC labels directly. The integer codes track a
+specific exciting/LibXC version (see *Known limitations*).
+
+### FHI-aims
+
+FHI-aims prints a descriptive control string per functional, which the parser
+maps to the corresponding standard name.
+
+### GPAW
+
+GPAW records a standard functional name directly and the parser passes it
+through unchanged.
+
+### octopus
+
+octopus prints the exchange and correlation parts as separate descriptive lines
+(`Slater exchange`, `Perdew & Zunger (Modified)`), which the parser maps to LibXC
+short-labels. The `XCFunctional` input variable is additionally an integer that
+is the *sum* of per-piece codes; when present it is decoded as a fallback to
+recover parts the descriptions did not name.
+
+### Quantum ESPRESSO
+
+QE prints XC either as a single name (`PBE`) or as its four DFT slot codes —
+exchange, correlation, gradient-exchange, gradient-correlation. `SLA PW PBX PBC`
+is Slater exchange + Perdew–Wang correlation + PBE gradient terms, i.e. PBE;
+`SLA PZ` is the Perdew–Zunger LDA. The parser recognises the common slot
+combinations and, for anything else, keeps the raw slot string so the reported
+XC is preserved rather than dropped.
+
+### VASP
+
+VASP emits no functional name, so the canonical name is reconstructed from the
+input tags in the order VASP itself resolves them: an explicit hybrid setup
+wins, then `METAGGA`, then `GGA`.
+
+The `GGA` and `METAGGA` tags are short two-letter codes (`PE` → PBE, `PS` →
+PBEsol, `RP` → RPBE, `RE` → revPBE, …). A few subtleties are worth stating:
+
+- **Hybrids** (`LHFCALC = .TRUE.`) are decided from `HFSCREEN`, `GGA` and `AEXX`
+  together, not from the screening length alone. `HFSCREEN = 0.2`/`0.3` give the
+  screened HSE hybrids, but the base GGA sets the variant: a PBE base gives
+  HSE06/HSE03, whereas `GGA = PS` (PBEsol) gives **HSEsol**. The unscreened
+  global hybrid **PBE0** additionally requires that screening is off, i.e.
+  `HFSCREEN = 0` — which is VASP's default, so it holds whether the tag is
+  explicitly zero or absent. `AEXX = 1` with no DFT correlation is pure
+  Hartree–Fock, not a DFT functional.
+- `GGA = B3` and `GGA = B5` are both B3LYP but with **different correlation** —
+  VWN3 (`B3` → `B3LYP`) versus VWN5 (`B5` → `B3LYP5`) — so they must not collapse
+  to one key.
+- When `GGA` is unset the effective functional is the **POTCAR default**, carried
+  by `LEXCH` (e.g. `LEXCH = CA` is the Ceperley–Alder LDA in the Perdew–Zunger
+  parametrisation, `PZ81`). PBE is assumed only when neither `GGA` nor `LEXCH`
+  is present.
+
+## Known limitations
+
+Some codes tie their XC identifiers to a specific LibXC (or code) release, so a
+mapping that is correct for one version can drift in another — ABINIT's negative
+`ixc` LibXC ids and exciting's integer `xctype` codes are the main examples.
+Mappings should be cross-checked against the LibXC version the code is built with
+when in doubt. Open verification items are tracked in the parser repository's
+issues.
+
+## References
+
+The LibXC label taxonomy and each code's XC-input documentation:
+
+- LibXC functional list — <https://libxc.gitlab.io/functionals/>
+- ABINIT — the [`ixc`](https://docs.abinit.org/variables/basic/#ixc) input variable
+- AMS / ADF — [Density Functionals (XC)](https://www.scm.com/doc/ADF/Input/Density_Functional.html)
+- CRYSTAL — the `DFT`/`EXCHANGE`/`CORRELAT` keywords in the
+  [CRYSTAL23 user's manual](https://www.crystal.unito.it/include/manuals/crystal23.pdf)
+- exciting — the [`groundstate`/`xctype`](http://exciting-code.org/ref:groundstate) reference
+- FHI-aims — the `xc` keyword ([manual §3.3](https://fhi-aims.org/uploads/manual/Ch3/S3.html))
+- GPAW — [exchange–correlation functionals](https://gpaw.readthedocs.io/documentation/xc/functionals.html)
+- octopus — the [`XCFunctional`](https://octopus-code.org/documentation/13/variables/hamiltonian/xc/xcfunctional/) variable
+- Quantum ESPRESSO — [`input_dft`](https://www.quantum-espresso.org/Doc/INPUT_PW.html)
+  (the slot codes are defined in `Modules/funct.f90` / `XClib`)
+- VASP — [`GGA`](https://www.vasp.at/wiki/index.php/GGA),
+  [`METAGGA`](https://www.vasp.at/wiki/index.php/METAGGA),
+  [`LHFCALC`](https://www.vasp.at/wiki/index.php/LHFCALC) and the
+  [list of hybrid functionals](https://www.vasp.at/wiki/index.php/List_of_hybrid_functionals)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,9 @@ nav:
       - VASP:
           - About: parsers/vasp/vasp_about.md
 
-  - Explanation: explanation/explanation.md
+  - Explanation:
+      - Overview: explanation/explanation.md
+      - Exchange-correlation functionals: explanation/xc-functionals.md
   - Reference: reference/references.md
 plugins:
   - search

--- a/src/nomad_simulation_parsers/parsers/abinit/parser.py
+++ b/src/nomad_simulation_parsers/parsers/abinit/parser.py
@@ -558,16 +558,24 @@ class MainfileParser(TextParser):
     def get_xc_functionals(self) -> list[dict[str, Any]]:
         ixc = self.get_input_var('ixc', 1, 1, scalar=True)
         if ixc >= 0:
-            xc_functionals = ABINIT_NATIVE_IXC.get(ixc, [])
-        else:
-            xc_functionals = []
-            functional1 = -ixc // 1000
-            if functional1 > 0:
-                xc_functionals.append(ABINIT_LIBXC_IXC.get(functional1))
-            functional2 = -ixc - (-ixc // 1000) * 1000
-            if functional2 > 0:
-                xc_functionals.append(ABINIT_LIBXC_IXC.get(functional2))
-        return xc_functionals
+            return [
+                {'unidentified': True}
+                if functional.get('XC_functional_name') == '?'
+                else functional
+                for functional in ABINIT_NATIVE_IXC.get(ixc, [])
+            ]
+        # LibXC path: the negative value packs two LibXC ids positionally. Id 0
+        # means the slot carries no functional; a non-zero id absent from the
+        # table is handed to the schema as a raw LibXC id to resolve or mark.
+        functional1 = -ixc // 1000
+        functional2 = -ixc - functional1 * 1000
+        components = []
+        for functional_id in (functional1, functional2):
+            if functional_id == 0:
+                continue
+            mapped = ABINIT_LIBXC_IXC.get(functional_id)
+            components.append(mapped if mapped else {'libxc_id': functional_id})
+        return components
 
     def get_bandstructures(
         self, eigenvalues: np.ndarray, occupations: np.ndarray

--- a/src/nomad_simulation_parsers/parsers/ams/parser.py
+++ b/src/nomad_simulation_parsers/parsers/ams/parser.py
@@ -46,16 +46,26 @@ class MainfileParser(TextParser):
     def logger(self):
         return LOGGER
 
-    def get_xc_functionals(self, source: dict[str, Any]) -> list[str]:
-        xc_functionals = []
-        for xc_type in ['LDA', 'GGA', 'MGGA']:
-            functionals = source.get(xc_type, '').split()
-            kind = ['XC'] if len(functionals) == 1 else ['X', 'C']
-            for n, functional in enumerate(functionals):
-                xc_functionals.append(
-                    f'{xc_type}_{kind[n]}_{functional.rstrip("x").rstrip("c").upper()}'
-                )
-        return xc_functionals
+    # AMS reports the active functional per rung ('LDA:', 'Gradient Corrections:',
+    # 'Meta-GGA:'); the highest present rung is the functional in effect. Map the
+    # AMS spelling to a standard functional name; the schema expands the name into
+    # LibXC components and derives `jacobs_ladder`. Unmapped strings pass through
+    # unchanged (a single token is usually already a standard name).
+    _ams_name_map = {
+        'Becke Perdew': 'BP86',
+        'Becke LYP': 'BLYP',
+        'BP': 'BP86',
+        'M06L': 'M06-L',
+        'M06-L': 'M06-L',
+    }
+
+    def get_functional_key(self, source: dict[str, Any]) -> str | None:
+        for rung in ('MGGA', 'GGA', 'LDA'):
+            value = (source.get(rung) or '').strip()
+            if not value:
+                continue
+            return self._ams_name_map.get(value, value)
+        return None
 
     def get_periodic_boundary_conditions(
         self, source: dict[str, Any] | Any

--- a/src/nomad_simulation_parsers/parsers/crystal/parser.py
+++ b/src/nomad_simulation_parsers/parsers/crystal/parser.py
@@ -45,7 +45,7 @@ class CrystalOutputParser(TextParser):
         'LDA': ['LDA_X'],
         'PWGGA': ['GGA_X_PW91', 'GGA_C_PW91'],
         'PZ': ['LDA_C_PZ'],
-        'WFN': ['LDA_C_VWN'],
+        'VWN': ['LDA_C_VWN'],
     }
 
     @property

--- a/src/nomad_simulation_parsers/parsers/exciting/parser.py
+++ b/src/nomad_simulation_parsers/parsers/exciting/parser.py
@@ -76,15 +76,15 @@ class InfoParser(TextParser):
 
     def get_xc_functionals(self, xc_type: int) -> list[dict[str, Any]]:
         xc_functional_map = {
-            2: ['LDA_C_PZ', 'LDA_X_PZ'],
-            3: ['LDA_C_PW', 'LDA_X_PZ'],
+            2: ['LDA_C_PZ', 'LDA_X'],
+            3: ['LDA_C_PW', 'LDA_X'],
             4: ['LDA_C_XALPHA'],
             5: ['LDA_C_VBH'],
             20: ['GGA_C_PBE', 'GGA_X_PBE'],
             21: ['GGA_C_PBE', 'GGA_X_PBE_R'],
             22: ['GGA_C_PBE_SOL', 'GGA_X_PBE_SOL'],
             26: ['GGA_C_PBE', 'GGA_X_WC'],
-            30: ['GGA_C_AM05', 'GGA_C_AM05'],
+            30: ['GGA_C_AM05', 'GGA_X_AM05'],
             300: ['GGA_C_BGCP', 'GGA_X_PBE'],
             406: ['HYB_GGA_XC_PBEH'],
             408: ['HYB_GGA_XC_HSE03'],
@@ -495,10 +495,11 @@ class ExcitingArchiveWriter(ArchiveWriter):
                 info_parser.filepath = info_out
                 info_parser.convert(data_parser)
 
-        # read xc functionals from input.xml
+        # read xc functionals from input.xml only if INFO.OUT did not already
+        # populate them
         input_xml_files = (
             search_files('input.xml', maindir, re_pattern=mainbase)
-            if not self.archive.m_xpath('data.model_method[0].xc_functionals')
+            if not self.archive.m_xpath('data.model_method[0].xc.components')
             else []
         )
         if input_xml_files:

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -68,112 +68,39 @@ class FHIAimsOutMappingParser(TextMappingParser):
         'scgw': 'scGW',
     }
 
-    _xc_map = {
-        'Perdew-Wang parametrisation of Ceperley-Alder LDA': [
-            {'name': 'LDA_C_PW'},
-            {'name': 'LDA_X'},
-        ],
-        'Perdew-Zunger parametrisation of Ceperley-Alder LDA': [
-            {'name': 'LDA_C_PZ'},
-            {'name': 'LDA_X'},
-        ],
-        'VWN-LDA parametrisation of VWN5 form': [
-            {'name': 'LDA_C_VWN'},
-            {'name': 'LDA_X'},
-        ],
-        'VWN-LDA parametrisation of VWN-RPA form': [
-            {'name': 'LDA_C_VWN_RPA'},
-            {'name': 'LDA_X'},
-        ],
-        'AM05 gradient-corrected functionals': [
-            {'name': 'GGA_C_AM05'},
-            {'name': 'GGA_X_AM05'},
-        ],
-        'BLYP functional': [{'name': 'GGA_C_LYP'}, {'name': 'GGA_X_B88'}],
-        'PBE gradient-corrected functionals': [
-            {'name': 'GGA_C_PBE'},
-            {'name': 'GGA_X_PBE'},
-        ],
-        'PBEint gradient-corrected functional': [
-            {'name': 'GGA_C_PBEINT'},
-            {'name': 'GGA_X_PBEINT'},
-        ],
-        'PBEsol gradient-corrected functionals': [
-            {'name': 'GGA_C_PBE_SOL'},
-            {'name': 'GGA_X_PBE_SOL'},
-        ],
-        'RPBE gradient-corrected functionals': [
-            {'name': 'GGA_C_PBE'},
-            {'name': 'GGA_X_RPBE'},
-        ],
-        'revPBE gradient-corrected functionals': [
-            {'name': 'GGA_C_PBE'},
-            {'name': 'GGA_X_PBE_R'},
-        ],
-        'PW91 gradient-corrected functionals': [
-            {'name': 'GGA_C_PW91'},
-            {'name': 'GGA_X_PW91'},
-        ],
-        'M06-L gradient-corrected functionals': [
-            {'name': 'MGGA_C_M06_L'},
-            {'name': 'MGGA_X_M06_L'},
-        ],
-        'M11-L gradient-corrected functionals': [
-            {'name': 'MGGA_C_M11_L'},
-            {'name': 'MGGA_X_M11_L'},
-        ],
-        'TPSS gradient-corrected functionals': [
-            {'name': 'MGGA_C_TPSS'},
-            {'name': 'MGGA_X_TPSS'},
-        ],
-        'TPSSloc gradient-corrected functionals': [
-            {'name': 'MGGA_C_TPSSLOC'},
-            {'name': 'MGGA_X_TPSS'},
-        ],
-        'hybrid B3LYP functional': [{'name': 'HYB_GGA_XC_B3LYP5'}],
-        'Hartree-Fock': [{'name': 'HF_X'}],
-        'HSE': [{'name': 'HYB_GGA_XC_HSE03'}],
-        'HSE-functional': [{'name': 'HYB_GGA_XC_HSE06'}],
-        'hybrid-PBE0 functionals': [
-            {'name': 'GGA_C_PBE'},
-            {
-                'name': 'GGA_X_PBE',
-                'weight': lambda x: 0.75 if x is None else 1.0 - x,
-            },
-            {'name': 'HF_X', 'weight': lambda x: 0.25 if x is None else x},
-        ],
-        'hybrid-PBEsol0 functionals': [
-            {'name': 'GGA_C_PBE_SOL'},
-            {
-                'name': 'GGA_X_PBE_SOL',
-                'weight': lambda x: 0.75 if x is None else 1.0 - x,
-            },
-            {'name': 'HF_X', 'weight': lambda x: 0.25 if x is None else x},
-        ],
-        'Hybrid M06 gradient-corrected functionals': [
-            {'name': 'MGGA_C_M06'},
-            {'name': 'HYB_MGGA_X_M06'},
-        ],
-        'Hybrid M06-2X gradient-corrected functionals': [
-            {'name': 'MGGA_C_M06_2X'},
-            {'name': 'HYB_MGGA_X_M06'},
-        ],
-        'Hybrid M06-HF gradient-corrected functionals': [
-            {'name': 'MGGA_C_M06_HF'},
-            {'name': 'HYB_MGGA_X_M06'},
-        ],
-        'Hybrid M08-HX gradient-corrected functionals': [
-            {'name': 'MGGA_C_M08_HX'},
-            {'name': 'HYB_MGGA_X_M08_HX'},
-        ],
-        'Hybrid M08-SO gradient-corrected functionals': [
-            {'name': 'MGGA_C_M08_SO'},
-            {'name': 'HYB_MGGA_X_M08_SO'},
-        ],
-        'Hybrid M11 gradient-corrected functionals': [
-            {'name': 'MGGA_C_M11'},
-            {'name': 'HYB_MGGA_X_M11'},
-        ],
+    # FHI-aims XC control description -> standard functional name. The
+    # `nomad-simulations` schema expands the name into LibXC components
+    # (family/kind) and derives `jacobs_ladder`; the parser deliberately does
+    # not resolve LibXC labels itself. Names normalize case-insensitively, so
+    # the human-readable spelling used here resolves to the schema alias.
+    _xc_name_map = {
+        'Perdew-Wang parametrisation of Ceperley-Alder LDA': 'LDA',
+        'Perdew-Zunger parametrisation of Ceperley-Alder LDA': 'PZ81',
+        'VWN-LDA parametrisation of VWN5 form': 'VWN',
+        'VWN-LDA parametrisation of VWN-RPA form': 'VWN-RPA',
+        'AM05 gradient-corrected functionals': 'AM05',
+        'BLYP functional': 'BLYP',
+        'PBE gradient-corrected functionals': 'PBE',
+        'PBEint gradient-corrected functional': 'PBEint',
+        'PBEsol gradient-corrected functionals': 'PBEsol',
+        'RPBE gradient-corrected functionals': 'RPBE',
+        'revPBE gradient-corrected functionals': 'revPBE',
+        'PW91 gradient-corrected functionals': 'PW91',
+        'M06-L gradient-corrected functionals': 'M06-L',
+        'M11-L gradient-corrected functionals': 'M11-L',
+        'TPSS gradient-corrected functionals': 'TPSS',
+        'TPSSloc gradient-corrected functionals': 'TPSSloc',
+        'hybrid B3LYP functional': 'B3LYP',
+        'HSE': 'HSE03',
+        'HSE-functional': 'HSE06',
+        'hybrid-PBE0 functionals': 'PBE0',
+        'hybrid-PBEsol0 functionals': 'PBEsol0',
+        'Hybrid M06 gradient-corrected functionals': 'M06',
+        'Hybrid M06-2X gradient-corrected functionals': 'M06-2X',
+        'Hybrid M06-HF gradient-corrected functionals': 'M06-HF',
+        'Hybrid M08-HX gradient-corrected functionals': 'M08-HX',
+        'Hybrid M08-SO gradient-corrected functionals': 'M08-SO',
+        'Hybrid M11 gradient-corrected functionals': 'M11',
     }
 
     _section_names = ['full_scf', 'geometry_optimization', 'molecular_dynamics']
@@ -193,10 +120,11 @@ class FHIAimsOutMappingParser(TextMappingParser):
         files.sort()
         return files
 
-    def get_xc_functionals(self, xc: str) -> list[dict[str, Any]]:
-        return [
-            dict(name=functional.get('name')) for functional in self._xc_map.get(xc, [])
-        ]
+    def get_functional_key(self, xc: str) -> str | None:
+        """Standard functional name for this FHI-aims XC control string. The
+        schema expands the name into LibXC components (family/kind) and derives
+        `jacobs_ladder`; returns `None` for an unmapped string."""
+        return self._xc_name_map.get(xc)
 
     def get_periodic_boundary_conditions(self, source: dict[str, Any]) -> list[bool]:
         return [source.get('lattice_vectors') is not None] * 3

--- a/src/nomad_simulation_parsers/parsers/gpaw/gpw_parser.py
+++ b/src/nomad_simulation_parsers/parsers/gpaw/gpw_parser.py
@@ -304,22 +304,6 @@ class GPWFileParser(FileParser):
         'bohr': ureg.bohr,
         'femtosecond': ureg.fs,
     }
-    _xc_map = {
-        'LDA': ['LDA_X', 'LDA_C_PW'],
-        'PW91': ['GGA_X_PW91', 'GGA_C_PW91'],
-        'PBE': ['GGA_X_PBE', 'GGA_C_PBE'],
-        'PBEsol': ['GGA_X_PBE_SOL', 'GGA_C_PBE_SOL'],
-        'revPBE': ['GGA_X_PBE_R', 'GGA_C_PBE'],
-        'RPBE': ['GGA_X_RPBE', 'GGA_C_PBE'],
-        'BLYP': ['GGA_X_B88', 'GGA_C_LYP'],
-        'HCTH407': ['GGA_XC_HCTH_407'],
-        'WC': ['GGA_X_WC', 'GGA_C_PBE'],
-        'AM05': ['GGA_X_AM05', 'GGA_C_AM05'],
-        'M06-L': ['MGGA_X_M06_L', 'MGGA_C_M06_L'],
-        'TPSS': ['MGGA_X_TPSS', 'MGGA_C_TPSS'],
-        'revTPSS': ['MGGA_X_REVTPSS', 'MGGA_C_REVTPSS'],
-        'mBEEF': ['MGGA_X_MBEEF', 'GGA_C_PBE_SOL'],
-    }
     parser = GPWTarParser()
 
     def apply_unit(self, val: np.ndarray | float, unit: str) -> pint.Quantity:
@@ -363,7 +347,6 @@ class GPWFileParser(FileParser):
             bc.shape = [bc.size]
             pbc[: bc.size] = bc
         self._results['boundary_conditions'] = pbc
-        xc_functional = self.parser.get_parameter('xcfunctional')
-        self._results['xcfunctional'] = [
-            xc for xc in self._xc_map.get(xc_functional, [xc_functional])
-        ]
+        # GPAW records the standard functional name (e.g. 'PBE', 'revPBE');
+        # the schema expands it into LibXC components and derives `jacobs_ladder`.
+        self._results['xcfunctional'] = self.parser.get_parameter('xcfunctional')

--- a/src/nomad_simulation_parsers/parsers/octopus/parser.py
+++ b/src/nomad_simulation_parsers/parsers/octopus/parser.py
@@ -36,6 +36,7 @@ class OctopusMainfileParser(TextParser):
     # TODO resolve solely from the integer value
     _xc_functionals = {
         'Exchange': ('lda_x', 1),
+        'Slater exchange': ('lda_x', 1),
         'Wigner parametrization': ('lda_c_wigner', 2000),
         'Random Phase Approximation': ('lda_c_rpa', 3000),
         'Hedin & Lundqvist': ('lda_c_hl', 4000),
@@ -63,7 +64,7 @@ class OctopusMainfileParser(TextParser):
         'Lee and Parr Gaussian ansatz': ('lda_k_lp', 51),
         'Perdew, Burke & Ernzerhof exchange': ('gga_x_pbe', 101),
         'Perdew, Burke & Ernzerhof exchange (revised)': ('gga_x_pbe_r', 102),
-        'Becke 86 Xalfa,beta,gamma': ('gga_x_2d_b86', 128),
+        'Becke 86 Xalfa,beta,gamma': ('gga_x_b86', 103),
         'Herman et al original GGA': ('gga_x_herman', 104),
         'Becke 86 Xalfa,beta,gamma (with mod. grad. correction)': (
             'gga_x_b86_mgc',

--- a/src/nomad_simulation_parsers/parsers/quantumespresso/common.py
+++ b/src/nomad_simulation_parsers/parsers/quantumespresso/common.py
@@ -331,7 +331,7 @@ general_quantities = [
     Quantity('mixing_scheme', r'number of iterations used\s*=\s*(\d+)\s*(.*)mixing'),
     Quantity(
         'xc_functional',
-        r'Exchange\-correlation\s*=\s*(.+)\s*(\([\d ]+\))',
+        r'Exchange\-correlation\s*=\s*(.+)',
         convert=False,
         flatten=False,
     ),

--- a/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
+++ b/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
@@ -36,7 +36,6 @@ from nomad_simulation_parsers.parsers.utils.general import (
 )
 from nomad_simulation_parsers.schema_packages.quantumespresso import common
 
-from .common import libxc_shortcut, xc_functional_map
 from .file_parser import QuantumEspressoFileParser
 from .pwscf.file_parser import PWSCFFileParser
 
@@ -51,37 +50,6 @@ class QuantumEspressoMetainfoParser(MetainfoParser):
     @property
     def logger(self):
         return LOGGER
-
-
-class XCFunctionalParser:
-    @staticmethod
-    def gen_string(data: dict[str, Any], separator='+') -> str:
-        string = ''
-        for key in sorted(data.keys()):
-            val = data[key]
-            weight = val.get('XC_functional_weight', 1.0)
-            if string and weight > 0:
-                string += separator
-            if weight is not None:
-                string += f'{weight:.3f}'
-            string += val.get('XC_functional_name', '')
-        return string
-
-    @staticmethod
-    def filter_data(data: dict[str, dict[str, Any]]) -> dict[str, Any]:
-        out = dict()
-        tol = 0.01
-        for key, val in data.items():
-            val_copy = val.copy()
-            weight = val_copy.get('XC_functional_weight')
-            if weight is None or abs(weight) < tol:
-                continue
-            else:
-                if abs(weight - 1.0) < tol:
-                    del val_copy['XC_functional_weight']
-                val_copy.pop('exx_compute_weight', None)
-            out[key] = val_copy
-        return out
 
 
 def get_program_name_version(header: str) -> tuple[str, tuple[int]]:
@@ -144,80 +112,41 @@ class MainfileTextParser(TextParser):
             if key != 'energy_total' and val is not None
         ]
 
-    def get_xc_functionals(self, source: str) -> list[dict[str, Any]]:
-        # Keep legacy behavior for additional '(' while satisfying PLC0207.
-        numbers = source.split('(', maxsplit=2)[1].split(')', maxsplit=1)[0]
-        nval = (4, 10)
-        # handle different formatting
-        if len(numbers) == nval[0]:
-            # 4-digit format without spaces
-            numbers_split = re.findall(r'(\d)', numbers)
-        elif len(numbers) == nval[1]:
-            # 5-digit format with/without spaces
-            numbers_split = re.findall(r'[ \d]\d', numbers)
-        else:
-            # 6-digit with spaces
-            numbers_split = numbers.split()
+    # Quantum ESPRESSO prints the XC either as a single functional name ('PBE')
+    # or as the four DFT slot codes ('SLA PW PBX PBC'), optionally followed by
+    # the numeric slot codes in parentheses. Map the slot combination to a
+    # standard functional name; the schema expands it into LibXC components and
+    # derives `jacobs_ladder`.
+    _slot_combo_names = {
+        'SLA PZ': 'PZ81',
+        'SLA PW': 'LDA',
+        'SLA VWN': 'VWN',
+        'SLA PW PBX PBC': 'PBE',
+        'SLA PW PSX PSC': 'PBEsol',
+        'SLA PW HHNX PBC': 'RPBE',
+        'SLA PW REVX PBC': 'revPBE',
+        'SLA PW WCX PBC': 'WC',
+        'SLA PW GGX GGC': 'PW91',
+        'SLA PW B88 P86': 'BP86',
+        'SLA LYP B88 BLYP': 'BLYP',
+    }
 
-        if not numbers_split:
-            self.logger.warning(
-                'Unknown XC functional format', data=dict(value=numbers)
-            )
-            return []
-
-        numbers_split = [int(n) for n in numbers_split]
-        # numbers should have six digits
-        numbers_split.extend([0] * (6 - len(numbers_split)))
-
-        # map numbers to values
-        xc_section_method = dict()
-        xc_terms = dict()
-        xc_terms_remove = dict()
-
-        def get_data(source: list[dict[str, Any]]) -> dict[str, Any]:
-            data = dict()
-            exx_fraction = self.get_header('x_qe_exact_exchange_fraction', 0.0)
-            for term in source:
-                term_copy = term.copy()
-                weight = term_copy.get('exx_compute_weight', 1.0)
-                term_copy['XC_functional_weight'] = (
-                    weight(exx_fraction) if not isinstance(weight, float) else weight
-                )
-                data.setdefault(term_copy.get('XC_functional_name', ''), term_copy)
-            return data
-
-        for i in range(6):
-            xc_component = xc_functional_map[i]
-            xc_number = numbers_split[i]
-            if xc_number >= len(xc_component) or xc_component[xc_number] is None:
-                continue
-            xc_section_method.update(
-                xc_component[xc_number].get('xc_section_method', {})
-            )
-            xc_terms.update(get_data(xc_component[xc_number].get('xc_terms', [])))
-            xc_terms_remove.update(
-                get_data(xc_component[xc_number].get('xc_terms_remove', []))
-            )
-
-        # remove terms
-        for key, val in xc_terms_remove.items():
-            weight = val.get('XC_functional_weight')
-            xc_terms.setdefault(key, val)
-            xc_terms[key]['XC_functional_weight'] *= -(weight or -1.0)
-
-        # filter data
-        xc_terms = XCFunctionalParser.filter_data(xc_terms)
-
-        xc_functional_str = XCFunctionalParser.gen_string(xc_terms)
-        if xc_functional_str in libxc_shortcut:
-            # override for libXC compliance
-            xc_terms = get_data(libxc_shortcut[xc_functional_str]['xc_terms'])
-            xc_terms = XCFunctionalParser.filter_data(xc_terms)
-            xc_functional_str = XCFunctionalParser.gen_string(xc_terms)
-        # TODO make use of this
-        xc_section_method['XC_functional'] = xc_functional_str
-
-        return [xc_terms[key] for key in sorted(xc_terms.keys())]
+    def get_functional_key(self, source: str) -> str | None:
+        if not source:
+            return None
+        # Drop the trailing numeric slot codes '( 1 4 3 4 0 0)' when present.
+        tokens = source.split('(', 1)[0].split()
+        if not tokens:
+            return None
+        if len(tokens) == 1:
+            return tokens[0]
+        combo = ' '.join(tokens)
+        name = self._slot_combo_names.get(combo)
+        if name is None:
+            # preserve the raw slot combination so the reported XC is not dropped
+            self.logger.debug('unmapped QE XC slot combination', data=dict(value=combo))
+            return combo
+        return name
 
     def get_value(self, source: dict[str, Any], key: str = '', units: str = 'units'):
         key_split = key.rsplit('.', 1)

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -71,21 +71,24 @@ def _hybrid_functional_key(parameters: dict[str, Any]) -> str | None:
         return 'HSE06'
     if hfscreen == _HFSCREEN_HSE03:
         return 'HSE03'
-    if gga == 'B3':
+    if gga in ('B3', 'B5'):
         return 'B3LYP'
     if aexx == 1.0 and aldac == 0.0 and aggac == 0.0:
         return None  # pure Hartree-Fock exchange, not a DFT functional
-    if gga == 'PE':
+    # Default hybrid is PBE0: GGA either unset (POTCAR default PBE) or PBE-family.
+    if gga in (None, 'PE', 'PBE'):
         return 'PBE0'
     return None
 
 
-def get_functional_key(parameters: dict[str, Any]) -> str | None:
+def functional_key_from_params(parameters: dict[str, Any]) -> str | None:
     """Map VASP XC input tags to a canonical functional name.
 
     Precedence follows VASP: an explicit hybrid/Hartree-Fock setup wins, then
     `METAGGA`, then `GGA` (defaulting to PBE when unset). The schema expands the
-    returned name into LibXC components during normalization.
+    returned name into LibXC components during normalization. The per-source
+    `get_functional_key` transformer methods assemble `parameters` and delegate
+    here.
     """
     if parameters.get('LHFCALC'):
         return _hybrid_functional_key(parameters)

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -84,11 +84,13 @@ def _hybrid_functional_key(parameters: dict[str, Any]) -> str | None:
 def functional_key_from_params(parameters: dict[str, Any]) -> str | None:
     """Map VASP XC input tags to a canonical functional name.
 
-    Precedence follows VASP: an explicit hybrid/Hartree-Fock setup wins, then
-    `METAGGA`, then `GGA` (defaulting to PBE when unset). The schema expands the
-    returned name into LibXC components during normalization. The per-source
-    `get_functional_key` transformer methods assemble `parameters` and delegate
-    here.
+    vasprun.xml (and the OUTCAR) carry no XC/DFT/method section and VASP emits no
+    functional name, so the canonical name is reconstructed here from the input
+    tags. Precedence follows VASP's own resolution: an explicit
+    hybrid/Hartree-Fock setup wins, then `METAGGA`, then `GGA` (defaulting to PBE
+    when unset). The schema expands the returned name into LibXC components
+    during normalization. The per-source `get_functional_key` transformer methods
+    assemble `parameters` and delegate here.
     """
     if parameters.get('LHFCALC'):
         return _hybrid_functional_key(parameters)

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -75,6 +75,7 @@ def _hybrid_functional_key(parameters: dict[str, Any]) -> str | None:
     aexx = parameters.get('AEXX') or 0.0
     aggac = parameters.get('AGGAC')
     aldac = parameters.get('ALDAC')
+    # an absent HFSCREEN normalizes to VASP's default, 0 (unscreened)
     hfscreen = parameters.get('HFSCREEN') or 0.0
     pbe_family = gga in (None, 'PE', 'PBE')
 
@@ -89,7 +90,8 @@ def _hybrid_functional_key(parameters: dict[str, Any]) -> str | None:
         return 'HSE06' if pbe_family else ('HSEsol' if gga == 'PS' else None)
     if hfscreen == 0.3:  # noqa: PLR2004 — HSE03 screening length (1/Angstrom)
         return 'HSE03' if pbe_family else None
-    # Unscreened global hybrid PBE0: no screening and a PBE-family base GGA.
+    # Unscreened global hybrid PBE0: screening off (HFSCREEN 0 or unset) and a
+    # PBE-family base GGA.
     if hfscreen == 0.0 and pbe_family:
         return 'PBE0'
     return None

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -2,6 +2,10 @@
 
 from typing import Any
 
+from nomad.utils import get_logger
+
+LOGGER = get_logger(__name__)
+
 VASP_TAG_TO_FUNCTIONAL = {
     # GGA tag (`--` = POTCAR default is handled by the `PE` fallback)
     'PE': 'PBE',
@@ -95,6 +99,20 @@ def functional_key_from_params(parameters: dict[str, Any]) -> str | None:
     if parameters.get('LHFCALC'):
         return _hybrid_functional_key(parameters)
     if metagga := _clean_tag(parameters.get('METAGGA')):
-        return VASP_TAG_TO_FUNCTIONAL.get(metagga)
+        return _mapped_functional(metagga, 'METAGGA')
     gga = _clean_tag(parameters.get('GGA')) or 'PE'
-    return VASP_TAG_TO_FUNCTIONAL.get(gga)
+    return _mapped_functional(gga, 'GGA')
+
+
+def _mapped_functional(tag: str, source: str) -> str | None:
+    """Resolve a VASP tag to a canonical name, logging a present-but-unmapped tag.
+
+    Returns `None` for an unrecognized tag rather than the raw tag: `functional_key`
+    must be a canonical name the schema can expand, and VASP's short tags are not.
+    """
+    name = VASP_TAG_TO_FUNCTIONAL.get(tag)
+    if name is None:
+        LOGGER.debug(
+            'unmapped VASP %s tag %s; leaving functional_key unset', source, tag
+        )
+    return name

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -42,8 +42,6 @@ VASP_TAG_TO_FUNCTIONAL = {
     'MBJ': 'MBJ',
 }
 
-_HFSCREEN_HSE06, _HFSCREEN_HSE03 = 0.2, 0.3
-
 
 def _clean_tag(value: Any) -> str | None:
     """Return the XC tag as a clean string, or `None` when it is unset.
@@ -87,9 +85,9 @@ def _hybrid_functional_key(parameters: dict[str, Any]) -> str | None:
         return None  # pure Hartree-Fock exchange, not a DFT functional
     # Screened hybrids (HSE): the base GGA sets the variant (PBE -> HSE06/03,
     # PBEsol -> HSEsol); any other base is left unresolved.
-    if hfscreen == _HFSCREEN_HSE06:
+    if hfscreen == 0.2:  # noqa: PLR2004 — HSE06 screening length (1/Angstrom)
         return 'HSE06' if pbe_family else ('HSEsol' if gga == 'PS' else None)
-    if hfscreen == _HFSCREEN_HSE03:
+    if hfscreen == 0.3:  # noqa: PLR2004 — HSE03 screening length (1/Angstrom)
         return 'HSE03' if pbe_family else None
     # Unscreened global hybrid PBE0: no screening and a PBE-family base GGA.
     if hfscreen == 0.0 and pbe_family:
@@ -109,6 +107,10 @@ def functional_key_from_params(parameters: dict[str, Any]) -> str | None:
     The schema expands the returned name into LibXC components during
     normalization. The per-source `get_functional_key` transformer methods
     assemble `parameters` and delegate here.
+
+    The precedence (METAGGA over GGA, and LHFCALC selecting a hybrid) follows the
+    VASP tag documentation: https://www.vasp.at/wiki/index.php/METAGGA and
+    https://www.vasp.at/wiki/index.php/LHFCALC.
     """
     if parameters.get('LHFCALC'):
         return _hybrid_functional_key(parameters)

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -3,8 +3,7 @@
 from typing import Any
 
 VASP_TAG_TO_FUNCTIONAL = {
-    # GGA tag
-    '--': 'PBE',
+    # GGA tag (`--` = POTCAR default is handled by the `PE` fallback)
     'PE': 'PBE',
     'PBE': 'PBE',
     'PS': 'PBEsol',
@@ -41,12 +40,22 @@ _HFSCREEN_HSE06, _HFSCREEN_HSE03 = 0.2, 0.3
 
 
 def _clean_tag(value: Any) -> str | None:
-    """A VASP XC tag is only meaningful as a string; both sources report an unset
-    tag as a non-string (OUTCAR: bool `False`, vasprun: typed `--` string)."""
+    """Return the XC tag as a clean string, or `None` when it is unset.
+
+    The two sources spell "unset" differently: OUTCAR yields a non-string (bool
+    `False`, from the shared parameter converter), vasprun yields an absent
+    element or a `--`/`NONE` sentinel. All of them normalize to `None` here.
+    """
+    # TODO: OUTCAR reports an unset tag as bool `False` because `get_key_values`
+    # converts every logical token; normalizing unset XC tags to `None` on the
+    # OUTCAR side would let the non-string guard go, at the cost of
+    # METAGGA-specific handling around that shared converter.
     if not isinstance(value, str):
         return None
     tag = value.strip().strip('"').strip()
-    return tag or None
+    if not tag or tag.upper() in ('--', 'NONE'):
+        return None
+    return tag
 
 
 def _hybrid_functional_key(parameters: dict[str, Any]) -> str | None:
@@ -80,10 +89,7 @@ def get_functional_key(parameters: dict[str, Any]) -> str | None:
     """
     if parameters.get('LHFCALC'):
         return _hybrid_functional_key(parameters)
-
-    metagga = _clean_tag(parameters.get('METAGGA'))
-    if metagga and metagga not in ('--', 'NONE'):
+    if metagga := _clean_tag(parameters.get('METAGGA')):
         return VASP_TAG_TO_FUNCTIONAL.get(metagga)
-
     gga = _clean_tag(parameters.get('GGA')) or 'PE'
     return VASP_TAG_TO_FUNCTIONAL.get(gga)

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from nomad_simulations.schema_packages.utils.libxc.build import spec_from_label
+
 XC_FUNCTIONAL_MAPPING = {
     '--': ['GGA_X_PBE', 'GGA_C_PBE'],
     'HL': ['LDA_C_HL'],
@@ -44,45 +46,56 @@ XC_FUNCTIONAL_MAPPING = {
 }
 
 
-def get_xc_functionals(parameters: dict[str, Any]) -> list[dict[str, Any]]:
-    xc_functionals = []
-    if parameters.get('LHFCALC', False):
-        hfscreen_06, hfscreen_03 = 0.2, 0.3
-        aexx_b3, aggax_b3, aggac_b3, aldac_b3 = 0.2, 0.72, 0.81, 0.19
-        xc_functional = {}
-        gga = parameters.get('GGA', 'PE')
-        aexx = parameters.get('AEXX', 0.0)
-        aggax = parameters.get('AGGAX', 1.0)
-        aggac = parameters.get('AGGAC', 1.0)
-        aldac = parameters.get('ALDAC', 1.0)
-        hfscreen = parameters.get('HFSCREEN', 0.0)
+def _xc_component(name: str) -> dict[str, Any]:
+    """Build one XC component dict, enriched with LibXC taxonomy from the shared
+    registry. `family` is what `DFT.normalize` uses to derive `jacobs_ladder`;
+    without it the ladder stays 'unavailable' even when components are present.
+    """
+    component: dict[str, Any] = {'name': name}
+    spec = spec_from_label(name)
+    if spec:
+        component['family'] = spec['family']
+        component['kind'] = spec['kind']
+    return component
 
-        if hfscreen == hfscreen_06:
-            xc_functional['name'] = 'HYB_GGA_XC_HSE06'
-        elif hfscreen == hfscreen_03:
-            xc_functional['name'] = 'HYB_GGA_XC_HSE03'
-        elif (
-            gga == 'B3'
-            and aexx == aexx_b3
-            and aggax == aggax_b3
-            and aggac == aggac_b3
-            and aldac == aldac_b3
-        ):
-            xc_functional['name'] = 'HYB_GGA_XC_B3LYP3'
-        elif aexx == 1.0 and aldac == 0.0 and aggac == 0.0:
-            xc_functional['name'] = 'HF_X'
-        elif gga == 'PE':
-            xc_functional['name'] = 'HYB_GGA_XC_PBEH'
-        else:
-            xc_functional['name'] = f'HYB_GGA_XC_{gga}'
-        xc_functionals.append(xc_functional)
+
+def _hybrid_functional_name(parameters: dict[str, Any]) -> str:
+    hfscreen_06, hfscreen_03 = 0.2, 0.3
+    aexx_b3, aggax_b3, aggac_b3, aldac_b3 = 0.2, 0.72, 0.81, 0.19
+    gga = parameters.get('GGA', 'PE')
+    aexx = parameters.get('AEXX', 0.0)
+    aggax = parameters.get('AGGAX', 1.0)
+    aggac = parameters.get('AGGAC', 1.0)
+    aldac = parameters.get('ALDAC', 1.0)
+    hfscreen = parameters.get('HFSCREEN', 0.0)
+
+    if hfscreen == hfscreen_06:
+        return 'HYB_GGA_XC_HSE06'
+    if hfscreen == hfscreen_03:
+        return 'HYB_GGA_XC_HSE03'
+    if (
+        gga == 'B3'
+        and aexx == aexx_b3
+        and aggax == aggax_b3
+        and aggac == aggac_b3
+        and aldac == aldac_b3
+    ):
+        return 'HYB_GGA_XC_B3LYP3'
+    if aexx == 1.0 and aldac == 0.0 and aggac == 0.0:
+        return 'HF_X'
+    if gga == 'PE':
+        return 'HYB_GGA_XC_PBEH'
+    return f'HYB_GGA_XC_{gga}'
+
+
+def get_xc_functionals(parameters: dict[str, Any]) -> list[dict[str, Any]]:
+    if parameters.get('LHFCALC', False):
+        return [_xc_component(_hybrid_functional_name(parameters))]
+
+    metagga = parameters.get('METAGGA')
+    if metagga:
+        functionals = XC_FUNCTIONAL_MAPPING.get(metagga, [metagga])
     else:
-        metagga = parameters.get('METAGGA')
-        if metagga:
-            functionals = XC_FUNCTIONAL_MAPPING.get(metagga, [metagga])
-        else:
-            # VASP defaults to PBE-like GGA if GGA is not explicitly set.
-            functionals = XC_FUNCTIONAL_MAPPING.get(parameters.get('GGA', 'PE'), [])
-        for functional in functionals:
-            xc_functionals.append({'name': functional})
-    return xc_functionals
+        # VASP defaults to PBE-like GGA if GGA is not explicitly set.
+        functionals = XC_FUNCTIONAL_MAPPING.get(parameters.get('GGA', 'PE'), [])
+    return [_xc_component(functional) for functional in functionals]

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -2,100 +2,88 @@
 
 from typing import Any
 
-from nomad_simulations.schema_packages.utils.libxc.build import spec_from_label
-
-XC_FUNCTIONAL_MAPPING = {
-    '--': ['GGA_X_PBE', 'GGA_C_PBE'],
-    'HL': ['LDA_C_HL'],
-    'WI': ['LDA_C_WIGNER'],
-    'PZ': ['LDA_C_PZ'],
-    '91': ['GGA_X_PW91', 'GGA_C_PW91'],
-    'PE': ['GGA_X_PBE', 'GGA_C_PBE'],
-    'PBE': ['GGA_X_PBE', 'GGA_C_PBE'],
-    'RE': ['GGA_X_PBE_R'],
-    'VW': ['LDA_C_VWN'],
-    'RP': ['GGA_X_RPBE', 'GGA_C_PBE'],
-    'PS': ['GGA_C_PBE_SOL', 'GGA_X_PBE_SOL'],
-    'AM': ['GGA_X_AM05', 'GGA_C_AM05'],
-    'B3': ['HYB_GGA_XC_B3LYP3'],
-    'B5': ['HYB_GGA_XC_B3LYP5'],
-    'BF': ['GGA_X_BEEFVDW', 'GGA_XC_BEEFVDW'],
-    'CO': [],  # TODO check if this is ever used
-    'OR': ['GGA_X_OPTPBE_VDW'],
-    'BO': ['GGA_X_OPTB88_VDW'],
-    'MK': ['GGA_X_OPTB86B_VDW'],
-    'ML': ['VDW_XC_DF2'],
-    'CX': ['VDW_XC_DF_CX'],
-    'TPSS': ['MGGA_X_TPSS', 'MGGA_C_TPSS'],
-    'RTPSS': ['MGGA_X_RTPSS'],
-    'M06L': ['MGGA_C_M06_L'],
-    'MS0': ['MGGA_X_MS0'],
-    'MS1': ['MGGA_X_MS1'],
-    'MS2': ['MGGA_X_MS2'],
-    'SCAN': ['MGGA_X_SCAN'],
-    'RSCAN': ['MGGA_X_RSCAN', 'MGGA_C_RSCAN'],
-    'R2SCAN': ['MGGA_X_R2SCAN', 'MGGA_C_R2SCAN'],
-    'SCANL': ['MGGA_X_SCANL', 'MGGA_C_SCANL'],
-    'RSCANL': [],  # not in LibXC, nor any paper, just deorbitalized SCANL
-    'R2SCANL': ['MGGA_X_R2SCANL', 'MGGA_C_R2SCANL'],
-    'OFR2': [],
-    'MBJ': ['MGGA_X_BJ06'],
-    'LBMJ': [],  # TODO ask Miguel Marquez
-    'HLE17': ['MGGA_XC_HLE17'],  # TODO check if this is ever used
-    'RA': ['LDA_C_PW_RPA'],  # TODO check if this is ever used
+VASP_TAG_TO_FUNCTIONAL = {
+    # GGA tag
+    '--': 'PBE',
+    'PE': 'PBE',
+    'PBE': 'PBE',
+    'PS': 'PBEsol',
+    'RP': 'RPBE',
+    'RE': 'revPBE',
+    '91': 'PW91',
+    'AM': 'AM05',
+    'HL': 'HL',
+    'WI': 'Wigner',
+    'PZ': 'PZ81',
+    'VW': 'VWN',
+    'B3': 'B3LYP',
+    'B5': 'B3LYP',
+    'OR': 'optPBE-vdW',
+    'BO': 'optB88-vdW',
+    'MK': 'optB86b-vdW',
+    'BF': 'BEEF-vdW',
+    # METAGGA tag
+    'TPSS': 'TPSS',
+    'RTPSS': 'revTPSS',
+    'M06L': 'M06-L',
+    'MS0': 'MS0',
+    'MS1': 'MS1',
+    'MS2': 'MS2',
+    'SCAN': 'SCAN',
+    'RSCAN': 'RSCAN',
+    'R2SCAN': 'R2SCAN',
+    'SCANL': 'SCAN-L',
+    'R2SCANL': 'R2SCAN-L',
+    'MBJ': 'MBJ',
 }
 
-
-def _xc_component(name: str) -> dict[str, Any]:
-    """Build one XC component dict, enriched with LibXC taxonomy from the shared
-    registry. `family` is what `DFT.normalize` uses to derive `jacobs_ladder`;
-    without it the ladder stays 'unavailable' even when components are present.
-    """
-    component: dict[str, Any] = {'name': name}
-    spec = spec_from_label(name)
-    if spec:
-        component['family'] = spec['family']
-        component['kind'] = spec['kind']
-    return component
+_HFSCREEN_HSE06, _HFSCREEN_HSE03 = 0.2, 0.3
 
 
-def _hybrid_functional_name(parameters: dict[str, Any]) -> str:
-    hfscreen_06, hfscreen_03 = 0.2, 0.3
-    aexx_b3, aggax_b3, aggac_b3, aldac_b3 = 0.2, 0.72, 0.81, 0.19
-    gga = parameters.get('GGA', 'PE')
-    aexx = parameters.get('AEXX', 0.0)
-    aggax = parameters.get('AGGAX', 1.0)
-    aggac = parameters.get('AGGAC', 1.0)
-    aldac = parameters.get('ALDAC', 1.0)
-    hfscreen = parameters.get('HFSCREEN', 0.0)
+def _clean_tag(value: Any) -> str | None:
+    """A VASP XC tag is only meaningful as a string; both sources report an unset
+    tag as a non-string (OUTCAR: bool `False`, vasprun: typed `--` string)."""
+    if not isinstance(value, str):
+        return None
+    tag = value.strip().strip('"').strip()
+    return tag or None
 
-    if hfscreen == hfscreen_06:
-        return 'HYB_GGA_XC_HSE06'
-    if hfscreen == hfscreen_03:
-        return 'HYB_GGA_XC_HSE03'
-    if (
-        gga == 'B3'
-        and aexx == aexx_b3
-        and aggax == aggax_b3
-        and aggac == aggac_b3
-        and aldac == aldac_b3
-    ):
-        return 'HYB_GGA_XC_B3LYP3'
+
+def _hybrid_functional_key(parameters: dict[str, Any]) -> str | None:
+    """Canonical functional name for a VASP hybrid run (LHFCALC set). Both source
+    parsers type their parameters, so values arrive as bool/float already."""
+    gga = _clean_tag(parameters.get('GGA'))
+    aexx = parameters.get('AEXX') or 0.0
+    aggac = parameters.get('AGGAC')
+    aldac = parameters.get('ALDAC')
+    hfscreen = parameters.get('HFSCREEN') or 0.0
+
+    if hfscreen == _HFSCREEN_HSE06:
+        return 'HSE06'
+    if hfscreen == _HFSCREEN_HSE03:
+        return 'HSE03'
+    if gga == 'B3':
+        return 'B3LYP'
     if aexx == 1.0 and aldac == 0.0 and aggac == 0.0:
-        return 'HF_X'
+        return None  # pure Hartree-Fock exchange, not a DFT functional
     if gga == 'PE':
-        return 'HYB_GGA_XC_PBEH'
-    return f'HYB_GGA_XC_{gga}'
+        return 'PBE0'
+    return None
 
 
-def get_xc_functionals(parameters: dict[str, Any]) -> list[dict[str, Any]]:
-    if parameters.get('LHFCALC', False):
-        return [_xc_component(_hybrid_functional_name(parameters))]
+def get_functional_key(parameters: dict[str, Any]) -> str | None:
+    """Map VASP XC input tags to a canonical functional name.
 
-    metagga = parameters.get('METAGGA')
-    if metagga:
-        functionals = XC_FUNCTIONAL_MAPPING.get(metagga, [metagga])
-    else:
-        # VASP defaults to PBE-like GGA if GGA is not explicitly set.
-        functionals = XC_FUNCTIONAL_MAPPING.get(parameters.get('GGA', 'PE'), [])
-    return [_xc_component(functional) for functional in functionals]
+    Precedence follows VASP: an explicit hybrid/Hartree-Fock setup wins, then
+    `METAGGA`, then `GGA` (defaulting to PBE when unset). The schema expands the
+    returned name into LibXC components during normalization.
+    """
+    if parameters.get('LHFCALC'):
+        return _hybrid_functional_key(parameters)
+
+    metagga = _clean_tag(parameters.get('METAGGA'))
+    if metagga and metagga not in ('--', 'NONE'):
+        return VASP_TAG_TO_FUNCTIONAL.get(metagga)
+
+    gga = _clean_tag(parameters.get('GGA')) or 'PE'
+    return VASP_TAG_TO_FUNCTIONAL.get(gga)

--- a/src/nomad_simulation_parsers/parsers/vasp/common.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/common.py
@@ -19,8 +19,10 @@ VASP_TAG_TO_FUNCTIONAL = {
     'WI': 'Wigner',
     'PZ': 'PZ81',
     'VW': 'VWN',
-    'B3': 'B3LYP',
-    'B5': 'B3LYP',
+    # LEXCH-only tag: POTCAR-default LDA (Ceperley-Alder, Perdew-Zunger)
+    'CA': 'PZ81',
+    'B3': 'B3LYP',  # B3LYP with VWN3 correlation
+    'B5': 'B3LYP5',  # B3LYP with VWN5 correlation
     'OR': 'optPBE-vdW',
     'BO': 'optB88-vdW',
     'MK': 'optB86b-vdW',
@@ -64,23 +66,33 @@ def _clean_tag(value: Any) -> str | None:
 
 def _hybrid_functional_key(parameters: dict[str, Any]) -> str | None:
     """Canonical functional name for a VASP hybrid run (LHFCALC set). Both source
-    parsers type their parameters, so values arrive as bool/float already."""
+    parsers type their parameters, so values arrive as bool/float already.
+
+    The variant is decided from `HFSCREEN`, `GGA` and `AEXX` together, not the
+    screening length alone: the screened HSE hybrids take their base GGA (PBE ->
+    HSE, PBEsol -> HSEsol), and the unscreened global hybrid PBE0 requires that
+    screening is off.
+    """
     gga = _clean_tag(parameters.get('GGA'))
     aexx = parameters.get('AEXX') or 0.0
     aggac = parameters.get('AGGAC')
     aldac = parameters.get('ALDAC')
     hfscreen = parameters.get('HFSCREEN') or 0.0
+    pbe_family = gga in (None, 'PE', 'PBE')
 
-    if hfscreen == _HFSCREEN_HSE06:
-        return 'HSE06'
-    if hfscreen == _HFSCREEN_HSE03:
-        return 'HSE03'
+    # B3LYP: VWN3 (GGA=B3) vs VWN5 (GGA=B5)
     if gga in ('B3', 'B5'):
-        return 'B3LYP'
+        return 'B3LYP' if gga == 'B3' else 'B3LYP5'
     if aexx == 1.0 and aldac == 0.0 and aggac == 0.0:
         return None  # pure Hartree-Fock exchange, not a DFT functional
-    # Default hybrid is PBE0: GGA either unset (POTCAR default PBE) or PBE-family.
-    if gga in (None, 'PE', 'PBE'):
+    # Screened hybrids (HSE): the base GGA sets the variant (PBE -> HSE06/03,
+    # PBEsol -> HSEsol); any other base is left unresolved.
+    if hfscreen == _HFSCREEN_HSE06:
+        return 'HSE06' if pbe_family else ('HSEsol' if gga == 'PS' else None)
+    if hfscreen == _HFSCREEN_HSE03:
+        return 'HSE03' if pbe_family else None
+    # Unscreened global hybrid PBE0: no screening and a PBE-family base GGA.
+    if hfscreen == 0.0 and pbe_family:
         return 'PBE0'
     return None
 
@@ -91,17 +103,22 @@ def functional_key_from_params(parameters: dict[str, Any]) -> str | None:
     vasprun.xml (and the OUTCAR) carry no XC/DFT/method section and VASP emits no
     functional name, so the canonical name is reconstructed here from the input
     tags. Precedence follows VASP's own resolution: an explicit
-    hybrid/Hartree-Fock setup wins, then `METAGGA`, then `GGA` (defaulting to PBE
-    when unset). The schema expands the returned name into LibXC components
-    during normalization. The per-source `get_functional_key` transformer methods
+    hybrid/Hartree-Fock setup wins, then `METAGGA`, then `GGA`. When `GGA` is
+    unset the effective functional is the POTCAR default, carried by `LEXCH`
+    (e.g. `CA` for an LDA POTCAR); PBE is assumed only when neither is present.
+    The schema expands the returned name into LibXC components during
+    normalization. The per-source `get_functional_key` transformer methods
     assemble `parameters` and delegate here.
     """
     if parameters.get('LHFCALC'):
         return _hybrid_functional_key(parameters)
     if metagga := _clean_tag(parameters.get('METAGGA')):
         return _mapped_functional(metagga, 'METAGGA')
-    gga = _clean_tag(parameters.get('GGA')) or 'PE'
-    return _mapped_functional(gga, 'GGA')
+    if gga := _clean_tag(parameters.get('GGA')):
+        return _mapped_functional(gga, 'GGA')
+    if lexch := _clean_tag(parameters.get('LEXCH')):
+        return _mapped_functional(lexch, 'LEXCH')
+    return _mapped_functional('PE', 'GGA')
 
 
 def _mapped_functional(tag: str, source: str) -> str | None:

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -33,7 +33,7 @@ from nomad_simulation_parsers.parsers.utils.general import (
 from nomad_simulation_parsers.schema_packages import vasp
 
 from .chgcar_parser import CHGCARParser
-from .common import get_xc_functionals
+from .common import get_functional_key as _functional_key_from_params
 
 RE_N = r'[\n\r]'
 LOGGER = get_logger(__name__)
@@ -499,8 +499,8 @@ class OutcarParser(MappingTextParser):
 
         return []
 
-    def get_xc_functionals(self, parameters: dict[str, Any]) -> list[dict[str, Any]]:
-        return get_xc_functionals(parameters)
+    def get_functional_key(self, parameters: dict[str, Any]) -> str | None:
+        return _functional_key_from_params(parameters)
 
     def get_scf_steps(self, source: dict[str, Any]) -> dict[str, Any]:
         scf_iterations = source.get('scf_iteration', [])

--- a/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/outcar_parser.py
@@ -33,7 +33,7 @@ from nomad_simulation_parsers.parsers.utils.general import (
 from nomad_simulation_parsers.schema_packages import vasp
 
 from .chgcar_parser import CHGCARParser
-from .common import get_functional_key as _functional_key_from_params
+from .common import functional_key_from_params
 
 RE_N = r'[\n\r]'
 LOGGER = get_logger(__name__)
@@ -500,7 +500,7 @@ class OutcarParser(MappingTextParser):
         return []
 
     def get_functional_key(self, parameters: dict[str, Any]) -> str | None:
-        return _functional_key_from_params(parameters)
+        return functional_key_from_params(parameters)
 
     def get_scf_steps(self, source: dict[str, Any]) -> dict[str, Any]:
         scf_iterations = source.get('scf_iteration', [])

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -32,7 +32,7 @@ from nomad_simulation_parsers.parsers.utils.general import (
 )
 from nomad_simulation_parsers.schema_packages import vasp
 
-from .common import get_functional_key as _functional_key_from_params
+from .common import functional_key_from_params
 from .outcar_parser import OutcarArchiveWriter
 
 LOGGER = get_logger(__name__)
@@ -411,15 +411,18 @@ class VasprunParser(XMLParser):
     def get_periodic_boundary_conditions(self) -> list[bool]:
         return [True, True, True]
 
-    def _find_parameter(self, name: str) -> Any:
-        """Recursively search the vasprun `<parameters>` tree for an `<i name=...>`,
-        returning its value typed by the element's `type` attribute (`logical` ->
-        bool, `int`/`float` -> number), mirroring the OUTCAR parameter typing.
+    def _find_parameters(self, names: tuple[str, ...]) -> dict[str, Any]:
+        """Collect the requested `<i name=...>` values from the vasprun
+        `<parameters>` tree in a single pre-order walk, typing each by its `type`
+        attribute (`logical` -> bool, `int`/`float` -> number), mirroring the
+        OUTCAR parameter typing.
 
         The XC-relevant tags (`GGA`, `METAGGA`, `LHFCALC`, `AEXX`, ...) live in
-        different, sometimes nested, `<separator>` blocks, so a flat lookup of a
-        single bound node is not enough.
+        different, sometimes nested, `<separator>` blocks, so one traversal that
+        gathers them all avoids re-walking the tree per key. First match wins.
         """
+        wanted = set(names)
+        found: dict[str, Any] = {}
 
         def typed(item: dict[str, Any]) -> Any:
             value = item.get(self.value_key)
@@ -440,38 +443,28 @@ class VasprunParser(XMLParser):
                     except ValueError:
                         return text
 
-        def search(node: Any) -> Any:
-            if not isinstance(node, dict):
-                return None
+        def search(node: Any) -> None:
+            if not isinstance(node, dict) or len(found) == len(wanted):
+                return
             for item in as_list(node.get('i')):
-                if (
-                    isinstance(item, dict)
-                    and item.get(f'{self.attribute_prefix}name') == name
-                ):
-                    return typed(item)
+                if not isinstance(item, dict):
+                    continue
+                name = item.get(f'{self.attribute_prefix}name')
+                if name in wanted and name not in found:
+                    found[name] = typed(item)
             for sub in as_list(node.get('separator')):
-                found = search(sub)
-                if found is not None:
-                    return found
-            return None
+                if len(found) == len(wanted):
+                    break
+                search(sub)
 
-        parameters = self.data.get('modeling', {}).get('parameters', {})
-        return search(parameters)
+        search(self.data.get('modeling', {}).get('parameters', {}))
+        return found
 
     def get_functional_key(self, source: Any = None) -> str | None:
-        params = {
-            key: self._find_parameter(key)
-            for key in (
-                'GGA',
-                'METAGGA',
-                'LHFCALC',
-                'AEXX',
-                'AGGAC',
-                'ALDAC',
-                'HFSCREEN',
-            )
-        }
-        return _functional_key_from_params(params)
+        params = self._find_parameters(
+            ('GGA', 'METAGGA', 'LHFCALC', 'AEXX', 'AGGAC', 'ALDAC', 'HFSCREEN')
+        )
+        return functional_key_from_params(params)
 
 
 class XMLArchiveWriter(ArchiveWriter):

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -417,9 +417,14 @@ class VasprunParser(XMLParser):
         attribute (`logical` -> bool, `int`/`float` -> number), mirroring the
         OUTCAR parameter typing.
 
-        The XC-relevant tags (`GGA`, `METAGGA`, `LHFCALC`, `AEXX`, ...) live in
-        different, sometimes nested, `<separator>` blocks, so one traversal that
-        gathers them all avoids re-walking the tree per key. First match wins.
+        We read `modeling.parameters` (VASP's reprinted, default-resolved INCAR)
+        rather than `<incar>` (only the explicitly-set tags): a run using the
+        POTCAR-default functional omits `GGA` from `<incar>`, so only the
+        parameter set carries the effective value. The XC-relevant tags
+        (`GGA`, `METAGGA`, `LHFCALC`, `AEXX`, ...) live in different, sometimes
+        nested, `<separator>` blocks, so one traversal gathers them all instead
+        of re-walking the tree per key. Unfound tags are left absent from the
+        result (the consumer treats absence as unset), so the dict is sparse.
         """
         wanted = set(names)
         found: dict[str, Any] = {}
@@ -450,6 +455,9 @@ class VasprunParser(XMLParser):
                 if not isinstance(item, dict):
                     continue
                 name = item.get(f'{self.attribute_prefix}name')
+                # First match wins: a tag is normally unique in `<parameters>`,
+                # and pre-order makes the shallowest/earliest occurrence
+                # authoritative; the guard also avoids re-typing a found value.
                 if name in wanted and name not in found:
                     found[name] = typed(item)
             for sub in as_list(node.get('separator')):

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -32,7 +32,7 @@ from nomad_simulation_parsers.parsers.utils.general import (
 )
 from nomad_simulation_parsers.schema_packages import vasp
 
-from .common import get_xc_functionals
+from .common import get_functional_key as _functional_key_from_params
 from .outcar_parser import OutcarArchiveWriter
 
 LOGGER = get_logger(__name__)
@@ -411,19 +411,67 @@ class VasprunParser(XMLParser):
     def get_periodic_boundary_conditions(self) -> list[bool]:
         return [True, True, True]
 
-    def get_xc_functionals(self, source: dict[str, Any] | None) -> list[dict[str, str]]:
-        if source is None:
-            return []
-        raw_params = source.get('i') if isinstance(source, dict) else None
-        params = {}
-        for item in raw_params or []:
-            key = item.get(f'{self.attribute_prefix}name')
+    def _find_parameter(self, name: str) -> Any:
+        """Recursively search the vasprun `<parameters>` tree for an `<i name=...>`,
+        returning its value typed by the element's `type` attribute (`logical` ->
+        bool, `int`/`float` -> number), mirroring the OUTCAR parameter typing.
+
+        The XC-relevant tags (`GGA`, `METAGGA`, `LHFCALC`, `AEXX`, ...) live in
+        different, sometimes nested, `<separator>` blocks, so a flat lookup of a
+        single bound node is not enough.
+        """
+
+        def typed(item: dict[str, Any]) -> Any:
             value = item.get(self.value_key)
-            if key is not None:
-                params[key] = value
-        if not params:
-            return []
-        return get_xc_functionals(params)
+            if not isinstance(value, str):
+                return value
+            text = value.strip()
+            match item.get(f'{self.attribute_prefix}type'):
+                case 'logical':
+                    return text.strip('.').upper() in ('T', 'TRUE')
+                case 'string':
+                    return text
+                case 'int':
+                    return int(text) if text.lstrip('-').isdigit() else None
+                case _:
+                    # untyped numeric `<i>` default to float in vasprun
+                    try:
+                        return float(text)
+                    except ValueError:
+                        return text
+
+        def search(node: Any) -> Any:
+            if not isinstance(node, dict):
+                return None
+            for item in as_list(node.get('i')):
+                if (
+                    isinstance(item, dict)
+                    and item.get(f'{self.attribute_prefix}name') == name
+                ):
+                    return typed(item)
+            for sub in as_list(node.get('separator')):
+                found = search(sub)
+                if found is not None:
+                    return found
+            return None
+
+        parameters = self.data.get('modeling', {}).get('parameters', {})
+        return search(parameters)
+
+    def get_functional_key(self, source: Any = None) -> str | None:
+        params = {
+            key: self._find_parameter(key)
+            for key in (
+                'GGA',
+                'METAGGA',
+                'LHFCALC',
+                'AEXX',
+                'AGGAC',
+                'ALDAC',
+                'HFSCREEN',
+            )
+        }
+        return _functional_key_from_params(params)
 
 
 class XMLArchiveWriter(ArchiveWriter):

--- a/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
+++ b/src/nomad_simulation_parsers/parsers/vasp/xml_parser.py
@@ -470,7 +470,7 @@ class VasprunParser(XMLParser):
 
     def get_functional_key(self, source: Any = None) -> str | None:
         params = self._find_parameters(
-            ('GGA', 'METAGGA', 'LHFCALC', 'AEXX', 'AGGAC', 'ALDAC', 'HFSCREEN')
+            ('GGA', 'METAGGA', 'LHFCALC', 'AEXX', 'AGGAC', 'ALDAC', 'HFSCREEN', 'LEXCH')
         )
         return functional_key_from_params(params)
 

--- a/src/nomad_simulation_parsers/schema_packages/abinit.py
+++ b/src/nomad_simulation_parsers/schema_packages/abinit.py
@@ -71,6 +71,10 @@ class XCComponent(model_method.XCComponent):
     add_mapping_annotation(
         model_method.XCComponent.canonical_label, OUT_KEY, '.XC_functional_name'
     )
+    add_mapping_annotation(model_method.XCComponent.libxc_id, OUT_KEY, '.libxc_id')
+    add_mapping_annotation(
+        model_method.XCComponent.unidentified, OUT_KEY, '.unidentified'
+    )
 
 
 class XCFunctional(model_method.XCFunctional):

--- a/src/nomad_simulation_parsers/schema_packages/ams.py
+++ b/src/nomad_simulation_parsers/schema_packages/ams.py
@@ -45,22 +45,20 @@ class ModelSystem(model_system.ModelSystem):
     ).update(dict(ams_out=Mapper(mapper='.lattice_vectors')))
 
 
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper='.@')))
+class DFT(model_method.DFT):
+    # Materialize the `xc` subsection so its child `functional_key` mapper runs.
+    add_mapping_annotation(model_method.DFT.xc, OUT_KEY, '.@')
 
 
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(
-#         dict(
-#             out=Mapper(
-#                 mapper=('get_xc_functionals', ['.model_parameters.dft_potential'])
-#             )
-#         )
-#     )
+class XCFunctional(model_method.XCFunctional):
+    # Set `functional_key` to the standard functional name from the AMS DFT
+    # potential block; the schema expands it into components (family/kind) and
+    # derives `jacobs_ladder`.
+    add_mapping_annotation(
+        model_method.XCFunctional.functional_key,
+        OUT_KEY,
+        ('get_functional_key', ['.model_parameters.dft_potential']),
+    )
 
 
 class TotalEnergy(outputs.TotalEnergy):

--- a/src/nomad_simulation_parsers/schema_packages/crystal.py
+++ b/src/nomad_simulation_parsers/schema_packages/crystal.py
@@ -49,7 +49,7 @@ class XCComponent(model_method.XCComponent):
 
 class XCFunctional(model_method.XCFunctional):
     add_mapping_annotation(
-        model_method.XCFunctional.components, OUT_KEY, ('get_xc_functionals', ['.dft'])
+        model_method.XCFunctional.components, OUT_KEY, ('get_xc_functionals', ['.@'])
     )
 
 

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -93,18 +93,19 @@ class Program(general.Program):
 
 class DFT(model_method.DFT):
     add_mapping_annotation(numerical_settings.KSpace.m_def, TEXT_KEY, '.@')
+    # Materialize the `xc` subsection so its child `functional_key` mapper runs.
+    add_mapping_annotation(model_method.DFT.xc, TEXT_KEY, '.@')
 
 
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(text=Mapper(mapper=('get_xc_functionals', ['.controlInOut_xc']))))
-
-
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(text=Mapper(mapper='.name')))
+class XCFunctional(model_method.XCFunctional):
+    # Set `functional_key` to the standard functional name from the FHI-aims XC
+    # control string; the schema expands the name into components (family/kind)
+    # and derives `jacobs_ladder`.
+    add_mapping_annotation(
+        model_method.XCFunctional.functional_key,
+        TEXT_KEY,
+        ('get_functional_key', ['.controlInOut_xc']),
+    )
 
 
 class GW(model_method.GW):

--- a/src/nomad_simulation_parsers/schema_packages/gpaw.py
+++ b/src/nomad_simulation_parsers/schema_packages/gpaw.py
@@ -40,20 +40,17 @@ class ModelSystem(model_system.ModelSystem):
     add_mapping_annotation(model_system.AtomsState.m_def, GPW_KEY, '.labels')
 
 
-class XCComponent(model_method.XCComponent):
-    add_mapping_annotation(model_method.XCComponent.canonical_label, GPW_KEY, '.@')
+class DFT(model_method.DFT):
+    # Materialize the `xc` subsection so its child `functional_key` mapper runs.
+    add_mapping_annotation(model_method.DFT.xc, GPW_KEY, '.@')
 
 
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(gpw=Mapper(mapper='.@')))
-
-
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(gpw=Mapper(mapper='.xcfunctional')))
+class XCFunctional(model_method.XCFunctional):
+    # GPAW stores the standard functional name directly; the schema expands it
+    # into components (family/kind) and derives `jacobs_ladder`.
+    add_mapping_annotation(
+        model_method.XCFunctional.functional_key, GPW_KEY, '.xcfunctional'
+    )
 
 
 class TotalEnergy(outputs.TotalEnergy):

--- a/src/nomad_simulation_parsers/schema_packages/octopus.py
+++ b/src/nomad_simulation_parsers/schema_packages/octopus.py
@@ -23,16 +23,16 @@ class XCComponent(model_method.XCComponent):
     add_mapping_annotation(model_method.XCComponent.canonical_label, OUT_KEY, '.@')
 
 
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper='.@')))
+class XCFunctional(model_method.XCFunctional):
+    add_mapping_annotation(
+        model_method.XCFunctional.components,
+        OUT_KEY,
+        ('get_xc_functionals', ['.theory_level']),
+    )
 
 
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper=('get_xc_functionals', ['.theory_level']))))
+class DFT(model_method.DFT):
+    add_mapping_annotation(model_method.DFT.xc, OUT_KEY, '.@')
 
 
 class ModelSystem(model_system.ModelSystem):

--- a/src/nomad_simulation_parsers/schema_packages/quantumespresso/common.py
+++ b/src/nomad_simulation_parsers/schema_packages/quantumespresso/common.py
@@ -31,22 +31,24 @@ class Program(general.Program):
     )
 
 
-class XCComponent(model_method.XCComponent):
+class DFT(model_method.DFT):
+    # Materialize the `xc` subsection so its child `functional_key` mapper runs.
+    add_mapping_annotation(model_method.DFT.xc, OUT_KEY, '.@')
+    add_mapping_annotation(model_method.DFT.xc, XML_KEY, '.@')
+
+
+class XCFunctional(model_method.XCFunctional):
+    # The output prints a functional name or the four DFT slot codes; the XML
+    # carries a clean functional name. Both resolve to a standard name that the
+    # schema expands into components (family/kind) and `jacobs_ladder`.
     add_mapping_annotation(
-        model_method.XCComponent.canonical_label, OUT_KEY, '.XC_functional_name'
+        model_method.XCFunctional.functional_key,
+        OUT_KEY,
+        ('get_functional_key', ['.xc_functional']),
     )
-
-
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper='.XC_functional_name')))
-
-
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper=('get_xc_functionals', ['.xc_functional']))))
+    add_mapping_annotation(
+        model_method.XCFunctional.functional_key, XML_KEY, '.dft.functional'
+    )
 
 
 class AtomsState(model_system.AtomsState):

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -100,15 +100,13 @@ class XCFunctional(model_method.XCFunctional):
 
 
 class DFT(model_method.DFT):
-    # Bind the `xc` subsection to its source node so the child `functional_key`
-    # mapper runs. vasprun.xml: the `electronic exchange-correlation` separator
-    # nested under the `electronic` separator that `DFT.m_def` binds to. OUTCAR:
-    # the flat `parameters` dict that `DFT.m_def` binds to.
-    add_mapping_annotation(
-        model_method.DFT.xc,
-        XML_KEY,
-        '.separator[?"@name"==\'electronic exchange-correlation\'] | [0]',
-    )
+    # The binding only needs to materialize the `xc` subsection so the child
+    # `functional_key` mapper runs -- `get_functional_key` ignores the bound node
+    # and gathers the XC tags itself (walking the full vasprun `<parameters>`
+    # tree, or the flat OUTCAR parameters). So bind to the current node (`.@`,
+    # always present) for both sources rather than a specific nested separator
+    # that some vasprun variants omit.
+    add_mapping_annotation(model_method.DFT.xc, XML_KEY, '.@')
     add_mapping_annotation(model_method.DFT.xc, OUTCAR_KEY, '.@')
 
 

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -76,46 +76,10 @@ class Program(general.Program):
     )
 
 
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(
-#         dict(
-#             xml=MapperAnnotation(
-#                 mapper='.separator[?"@name"==\'electronic exchange-correlation\']'
-#             ),
-#             outcar=MapperAnnotation(mapper=('get_xc_functionals', ['.@'])),
-#         )
-#     )
-#     model_method.DFT.exact_exchange_mixing_factor.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(
-#         dict(
-#             xml=MapperAnnotation(
-#                 mapper=(
-#                     'mix_alpha',
-#                     [
-#                         '.i[?"@name"==\'HFALPHA\'] | [0].__value',
-#                         '.i[?"@name"==\'LHFCALC\'] | [0].__value',
-#                     ],
-#                 )
-#             )
-#         )
-#     )  # TODO convert vasp bool
-
-
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(
-#         dict(
-#             xml=MapperAnnotation(
-#                 # TODO add LDA & mGGA, convert_xc
-#                 mapper='.i[?"@name"==\'GGA\'] | [0].__value'
-#             ),
-#             outcar=MapperAnnotation(mapper='.name'),
-#         )
-#     )
+# TODO: map hybrid exact-exchange mixing into `XCFunctional.global_exact_exchange`
+# (formerly `DFT.exact_exchange_mixing_factor`). VASP exposes it via HFALPHA /
+# LHFCALC, and `VasprunParser.mix_alpha` is the intended transformer. Deferred:
+# needs a hybrid test fixture (AgAc_relax is PBE).
 class XCFunctional(model_method.XCFunctional):
     add_mapping_annotation(
         model_method.XCFunctional.components,
@@ -132,6 +96,30 @@ class XCComponent(model_method.XCComponent):
     add_mapping_annotation(
         model_method.XCComponent.canonical_label, OUTCAR_KEY, '.name'
     )
+    # LibXC taxonomy carried by `get_xc_functionals`; `family` feeds the
+    # `DFT.jacobs_ladder` derivation.
+    add_mapping_annotation(model_method.XCComponent.family, XML_KEY, '.family')
+    add_mapping_annotation(model_method.XCComponent.family, OUTCAR_KEY, '.family')
+    add_mapping_annotation(model_method.XCComponent.kind, XML_KEY, '.kind')
+    add_mapping_annotation(model_method.XCComponent.kind, OUTCAR_KEY, '.kind')
+
+
+class DFT(model_method.DFT):
+    # Bind the `xc` subsection to the source node holding the XC input parameters,
+    # so the child `XCFunctional.components` mapper (which invokes the
+    # source-specific `get_xc_functionals` transformer via `.@`) has a node to
+    # read. Without this binding the subsection is never sourced and `xc` stays
+    # empty, leaving `jacobs_ladder` unavailable.
+    #
+    # vasprun.xml: the `electronic exchange-correlation` separator, nested under
+    # the `electronic` separator that `DFT.m_def` binds to.
+    add_mapping_annotation(
+        model_method.DFT.xc,
+        XML_KEY,
+        '.separator[?"@name"==\'electronic exchange-correlation\'] | [0]',
+    )
+    # OUTCAR: the flat `parameters` dict that `DFT.m_def` binds to.
+    add_mapping_annotation(model_method.DFT.xc, OUTCAR_KEY, '.@')
 
 
 class ModelMethod(model_method.ModelMethod):

--- a/src/nomad_simulation_parsers/schema_packages/vasp.py
+++ b/src/nomad_simulation_parsers/schema_packages/vasp.py
@@ -81,44 +81,34 @@ class Program(general.Program):
 # LHFCALC, and `VasprunParser.mix_alpha` is the intended transformer. Deferred:
 # needs a hybrid test fixture (AgAc_relax is PBE).
 class XCFunctional(model_method.XCFunctional):
+    # Set only the canonical functional name; `XCFunctional.normalize` expands it
+    # into complete LibXC `components` (exchange + correlation, with family/kind)
+    # from the shared alias/registry tables, and `DFT.normalize` derives
+    # `jacobs_ladder`. The parser therefore does not build components itself. The
+    # `get_functional_key` transformer gathers the VASP XC tags itself (flat
+    # OUTCAR parameters, or by walking the vasprun `<parameters>` tree).
     add_mapping_annotation(
-        model_method.XCFunctional.components,
+        model_method.XCFunctional.functional_key,
         XML_KEY,
-        ('get_xc_functionals', ['.@']),
+        ('get_functional_key', ['.@']),
     )
     add_mapping_annotation(
-        model_method.XCFunctional.components, OUTCAR_KEY, ('get_xc_functionals', ['.@'])
+        model_method.XCFunctional.functional_key,
+        OUTCAR_KEY,
+        ('get_functional_key', ['.@']),
     )
-
-
-class XCComponent(model_method.XCComponent):
-    add_mapping_annotation(model_method.XCComponent.canonical_label, XML_KEY, '.name')
-    add_mapping_annotation(
-        model_method.XCComponent.canonical_label, OUTCAR_KEY, '.name'
-    )
-    # LibXC taxonomy carried by `get_xc_functionals`; `family` feeds the
-    # `DFT.jacobs_ladder` derivation.
-    add_mapping_annotation(model_method.XCComponent.family, XML_KEY, '.family')
-    add_mapping_annotation(model_method.XCComponent.family, OUTCAR_KEY, '.family')
-    add_mapping_annotation(model_method.XCComponent.kind, XML_KEY, '.kind')
-    add_mapping_annotation(model_method.XCComponent.kind, OUTCAR_KEY, '.kind')
 
 
 class DFT(model_method.DFT):
-    # Bind the `xc` subsection to the source node holding the XC input parameters,
-    # so the child `XCFunctional.components` mapper (which invokes the
-    # source-specific `get_xc_functionals` transformer via `.@`) has a node to
-    # read. Without this binding the subsection is never sourced and `xc` stays
-    # empty, leaving `jacobs_ladder` unavailable.
-    #
-    # vasprun.xml: the `electronic exchange-correlation` separator, nested under
-    # the `electronic` separator that `DFT.m_def` binds to.
+    # Bind the `xc` subsection to its source node so the child `functional_key`
+    # mapper runs. vasprun.xml: the `electronic exchange-correlation` separator
+    # nested under the `electronic` separator that `DFT.m_def` binds to. OUTCAR:
+    # the flat `parameters` dict that `DFT.m_def` binds to.
     add_mapping_annotation(
         model_method.DFT.xc,
         XML_KEY,
         '.separator[?"@name"==\'electronic exchange-correlation\'] | [0]',
     )
-    # OUTCAR: the flat `parameters` dict that `DFT.m_def` binds to.
     add_mapping_annotation(model_method.DFT.xc, OUTCAR_KEY, '.@')
 
 

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -11,6 +11,7 @@ from nomad.processing import Upload
 from nomad.utils import get_logger
 from pytest import approx
 
+from nomad_simulation_parsers.parsers.vasp.common import functional_key_from_params
 from nomad_simulation_parsers.parsers.vasp.outcar_parser import (
     OutcarParser,
     OutcarTextParser,
@@ -89,6 +90,31 @@ def test_outcar():
     assert sec_system.positions is not None
     assert sec_system.lattice_vectors is not None
     assert sec_system.periodic_boundary_conditions == [True, True, True]
+
+
+@pytest.mark.parametrize(
+    'parameters, expected',
+    [
+        pytest.param({'GGA': 'PE'}, 'PBE', id='gga-pe'),
+        pytest.param({'GGA': '--'}, 'PBE', id='gga-default'),
+        pytest.param({'METAGGA': 'SCAN'}, 'SCAN', id='metagga-scan'),
+        pytest.param({'LHFCALC': True, 'HFSCREEN': 0.2}, 'HSE06', id='hse06'),
+        pytest.param({'LHFCALC': True, 'HFSCREEN': 0.3}, 'HSE03', id='hse03'),
+        pytest.param({'LHFCALC': True, 'AEXX': 0.25}, 'PBE0', id='pbe0-gga-unset'),
+        pytest.param({'LHFCALC': True, 'GGA': 'PBE'}, 'PBE0', id='pbe0-gga-pbe'),
+        pytest.param({'LHFCALC': True, 'GGA': 'B5'}, 'B3LYP', id='b3lyp-b5'),
+        pytest.param({'LHFCALC': True, 'GGA': 'B3'}, 'B3LYP', id='b3lyp-b3'),
+        pytest.param(
+            {'LHFCALC': True, 'AEXX': 1.0, 'ALDAC': 0.0, 'AGGAC': 0.0},
+            None,
+            id='pure-hf',
+        ),
+    ],
+)
+def test_functional_key_from_params(parameters, expected):
+    """Tag-to-canonical-name mapping, including hybrids where GGA may be unset or
+    `PBE` (PBE0) or `B5` (B3LYP)."""
+    assert functional_key_from_params(parameters) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -99,23 +99,24 @@ def test_outcar():
     ],
 )
 def test_xc_functional_and_jacobs_ladder(mainfile):
-    """The XC functional maps into `DFT.xc` from both the vasprun.xml and OUTCAR
-    sources, carrying LibXC taxonomy, and `DFT.normalize` derives `jacobs_ladder`
-    from the component families. AgAc_relax uses PBE (GGA).
+    """The parser sets the canonical `functional_key` from both the vasprun.xml
+    and OUTCAR sources; `XCFunctional.normalize` expands it into complete LibXC
+    components, and `DFT.normalize` derives `jacobs_ladder`. AgAc_relax uses PBE.
     """
     archive = _parse(mainfile)
     dft = archive.data.model_method[0]
 
     assert dft.xc is not None
-    assert [c.canonical_label for c in dft.xc.components] == [
-        'GGA_X_PBE',
-        'GGA_C_PBE',
-    ]
-    assert [str(c.family) for c in dft.xc.components] == ['GGA', 'GGA']
-    assert [str(c.kind) for c in dft.xc.components] == ['exchange', 'correlation']
+    assert dft.xc.functional_key == 'PBE'
 
-    # jacobs_ladder is derived from the component families during normalization
+    # schema normalization expands the functional_key into LibXC components
     dft.normalize(archive, LOGGER)
+    assert {c.canonical_label for c in dft.xc.components} == {
+        'XC_GGA_X_PBE',
+        'XC_GGA_C_PBE',
+    }
+    assert {str(c.family) for c in dft.xc.components} == {'GGA'}
+    assert {str(c.kind) for c in dft.xc.components} == {'exchange', 'correlation'}
     assert dft.jacobs_ladder == 'GGA'
 
 

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -98,11 +98,26 @@ def test_outcar():
         pytest.param({'GGA': 'PE'}, 'PBE', id='gga-pe'),
         pytest.param({'GGA': '--'}, 'PBE', id='gga-default'),
         pytest.param({'METAGGA': 'SCAN'}, 'SCAN', id='metagga-scan'),
+        # unset GGA defers to the POTCAR default (LEXCH), not PBE
+        pytest.param({'LEXCH': 'CA'}, 'PZ81', id='lexch-ca-lda'),
         pytest.param({'LHFCALC': True, 'HFSCREEN': 0.2}, 'HSE06', id='hse06'),
         pytest.param({'LHFCALC': True, 'HFSCREEN': 0.3}, 'HSE03', id='hse03'),
+        # HSE variant follows the base GGA: PBEsol -> HSEsol, non-PBE -> unknown
+        pytest.param(
+            {'LHFCALC': True, 'HFSCREEN': 0.2, 'GGA': 'PS'}, 'HSEsol', id='hsesol'
+        ),
+        pytest.param(
+            {'LHFCALC': True, 'HFSCREEN': 0.2, 'GGA': 'RP'}, None, id='hse-non-pbe'
+        ),
         pytest.param({'LHFCALC': True, 'AEXX': 0.25}, 'PBE0', id='pbe0-gga-unset'),
         pytest.param({'LHFCALC': True, 'GGA': 'PBE'}, 'PBE0', id='pbe0-gga-pbe'),
-        pytest.param({'LHFCALC': True, 'GGA': 'B5'}, 'B3LYP', id='b3lyp-b5'),
+        # PBE0 requires screening off
+        pytest.param(
+            {'LHFCALC': True, 'AEXX': 0.25, 'HFSCREEN': 0.5},
+            None,
+            id='screened-not-pbe0',
+        ),
+        pytest.param({'LHFCALC': True, 'GGA': 'B5'}, 'B3LYP5', id='b3lyp5-b5'),
         pytest.param({'LHFCALC': True, 'GGA': 'B3'}, 'B3LYP', id='b3lyp-b3'),
         pytest.param(
             {'LHFCALC': True, 'AEXX': 1.0, 'ALDAC': 0.0, 'AGGAC': 0.0},
@@ -112,8 +127,8 @@ def test_outcar():
     ],
 )
 def test_functional_key_from_params(parameters, expected):
-    """Tag-to-canonical-name mapping, including hybrids where GGA may be unset or
-    `PBE` (PBE0) or `B5` (B3LYP)."""
+    """Tag-to-canonical-name mapping: GGA/METAGGA, the POTCAR-default LDA via
+    LEXCH, and hybrids decided from HFSCREEN + GGA + AEXX together."""
     assert functional_key_from_params(parameters) == expected
 
 

--- a/tests/parsers/test_vasp_parser.py
+++ b/tests/parsers/test_vasp_parser.py
@@ -91,6 +91,34 @@ def test_outcar():
     assert sec_system.periodic_boundary_conditions == [True, True, True]
 
 
+@pytest.mark.parametrize(
+    'mainfile',
+    [
+        pytest.param('tests/data/vasp/AgAc_relax/vasprun.xml.relax', id='vasprun'),
+        pytest.param('tests/data/vasp/AgAc_relax/OUTCAR', id='outcar'),
+    ],
+)
+def test_xc_functional_and_jacobs_ladder(mainfile):
+    """The XC functional maps into `DFT.xc` from both the vasprun.xml and OUTCAR
+    sources, carrying LibXC taxonomy, and `DFT.normalize` derives `jacobs_ladder`
+    from the component families. AgAc_relax uses PBE (GGA).
+    """
+    archive = _parse(mainfile)
+    dft = archive.data.model_method[0]
+
+    assert dft.xc is not None
+    assert [c.canonical_label for c in dft.xc.components] == [
+        'GGA_X_PBE',
+        'GGA_C_PBE',
+    ]
+    assert [str(c.family) for c in dft.xc.components] == ['GGA', 'GGA']
+    assert [str(c.kind) for c in dft.xc.components] == ['exchange', 'correlation']
+
+    # jacobs_ladder is derived from the component families during normalization
+    dft.normalize(archive, LOGGER)
+    assert dft.jacobs_ladder == 'GGA'
+
+
 def test_outcar_electronic_outputs_from_doscar_and_eigenvalues():
     archive = _parse('tests/data/vasp/AgAc_relax/OUTCAR')
 


### PR DESCRIPTION
## Purpose

The VASP parser did not populate the DFT method's exchange-correlation functional: the `DFT.xc` subsection was never wired (its mapping was commented out), so `archive.data.model_method[].xc` came out empty and `jacobs_ladder` was `unavailable`. This PR adds XC parsing end-to-end. Rather than hand-maintain a per-code tag-to-LibXC-label table, the parser emits a single canonical `functional_key` derived from the VASP `GGA`/`METAGGA`/hybrid tags, and the `nomad-simulations` schema expands it into complete, registry-validated `components` (with `family`/`kind`) and derives `jacobs_ladder`. Completeness lives once in the schema's shared alias/registry tables.

## Scope

**Included**

- Bind the `DFT.xc` subsection for both the vasprun.xml and OUTCAR sources (previously unmapped) so XC is parsed at all.
- Populate it via `get_functional_key` (`VASP_TAG_TO_FUNCTIONAL`, GGA/METAGGA/hybrid to canonical name) mapped onto `XCFunctional.functional_key`; the schema does the LibXC expansion and `jacobs_ladder` derivation.
- vasprun.xml: recursively walk `<parameters>`, typing values by the `<i type=...>` attribute — required to reach `GGA`/`METAGGA`/`LHFCALC` across nested separators.
- Centralize unset-tag normalization in `_clean_tag` (OUTCAR bool `False`, absent elements, `--`/`NONE` sentinels).
- Parametrized test over both sources.

**Out of scope**

- Migrating the other simulation parsers (QuantumESPRESSO, exciting, ...) to `functional_key` — they still emit components.
- Hybrid exact-exchange mixing into `XCFunctional.global_exact_exchange` (left as a `TODO`; needs a hybrid fixture).

## Context & Links

- Depends on the companion aliases PR: FAIRmat-NFDI/nomad-simulations#435 (must land first/together).

## Reviewer Notes

- `XCFunctional.normalize` only expands `functional_key` when `components` is empty, so the parser must not also emit components.
- Additive and verified non-destructive on a real vasprun (`case_1`): the `data` section is byte-identical to a pre-change run modulo timestamps/ordering, except `xc`/`jacobs_ladder` are now populated (`functional_key=PBE`, `jacobs_ladder=GGA`, `XC_GGA_X_PBE` + `XC_GGA_C_PBE`).
- `_clean_tag` owns cross-source normalization; a `TODO` notes the OUTCAR side could instead normalize unset tags at the source.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None — purely additive; `xc`/`jacobs_ladder` were empty before.

## Dependencies / Blockers

- [x] External dependencies: FAIRmat-NFDI/nomad-simulations#435.

## Testing / Validation

- [x] Unit tests — parametrized over vasprun.xml + OUTCAR asserting `functional_key`, expanded components, and derived `jacobs_ladder` (`12 passed, 1 skipped`).
- [x] Manual testing — `uv run nomad parse` on VASP samples; archive diff vs a pre-change run confirms XC is the only added content.
