### PR TITLE
Extend DFT exchange-correlation / Jacob's ladder parsing to the remaining parsers

### DIFF
--- a/docs/explanation/xc-functionals.md
+++ b/docs/explanation/xc-functionals.md
@@ -6,8 +6,9 @@ Every DFT code records the exchange–correlation (XC) functional in its own way
 an input tag, an integer code, or a human-readable line in the output — and only
 rarely as a single canonical name. The simulation parsers reduce that variety to
 one of two forms that the `nomad-simulations` schema understands, and leave the
-LibXC taxonomy (family, kind, and the derived Jacob's ladder rung) to the schema
-rather than reconstructing it per parser.
+[LibXC](https://libxc.gitlab.io/functionals/) taxonomy (family, kind, and the
+derived Jacob's ladder rung) to the schema rather than reconstructing it per
+parser.
 
 A parser produces either:
 
@@ -117,3 +118,23 @@ mapping that is correct for one version can drift in another — ABINIT's negati
 Mappings should be cross-checked against the LibXC version the code is built with
 when in doubt. Open verification items are tracked in the parser repository's
 issues.
+
+## References
+
+The LibXC label taxonomy and each code's XC-input documentation:
+
+- LibXC functional list — <https://libxc.gitlab.io/functionals/>
+- VASP — [`GGA`](https://www.vasp.at/wiki/index.php/GGA),
+  [`METAGGA`](https://www.vasp.at/wiki/index.php/METAGGA),
+  [`LHFCALC`](https://www.vasp.at/wiki/index.php/LHFCALC) and the
+  [list of hybrid functionals](https://www.vasp.at/wiki/index.php/List_of_hybrid_functionals)
+- ABINIT — the [`ixc`](https://docs.abinit.org/variables/basic/#ixc) input variable
+- Quantum ESPRESSO — [`input_dft`](https://www.quantum-espresso.org/Doc/INPUT_PW.html)
+  (the slot codes are defined in `Modules/funct.f90` / `XClib`)
+- octopus — the [`XCFunctional`](https://octopus-code.org/documentation/13/variables/hamiltonian/xc/xcfunctional/) variable
+- exciting — the [`groundstate`/`xctype`](http://exciting-code.org/ref:groundstate) reference
+- CRYSTAL — the `DFT`/`EXCHANGE`/`CORRELAT` keywords in the
+  [CRYSTAL23 user's manual](https://www.crystal.unito.it/include/manuals/crystal23.pdf)
+- AMS / ADF — [Density Functionals (XC)](https://www.scm.com/doc/ADF/Input/Density_Functional.html)
+- GPAW — [exchange–correlation functionals](https://gpaw.readthedocs.io/documentation/xc/functionals.html)
+- FHI-aims — the `xc` keyword ([manual §3.3](https://fhi-aims.org/uploads/manual/Ch3/S3.html))

--- a/docs/explanation/xc-functionals.md
+++ b/docs/explanation/xc-functionals.md
@@ -35,6 +35,62 @@ code's XC specification is indirect or easy to misread.
 
 ## How each code expresses XC
 
+### ABINIT
+
+ABINIT identifies XC by the single integer `ixc`. A non-negative `ixc` selects a
+built-in preset (`1` = Teter93 LDA, `11` = PBE, `14` = revPBE, `15` = RPBE,
+`23` = Wu–Cohen, …), mapped through a small table. A **negative** `ixc` packs two
+LibXC functional ids positionally as `-(1000·id_x + id_c)` — for example
+`ixc = -101130` is LibXC `101` (`XC_GGA_X_PBE`) plus `130` (`XC_GGA_C_PBE`),
+i.e. PBE. The parser emits those ids as components and lets the schema registry
+resolve them, which also covers ids the local table does not list.
+
+### AMS / ADF
+
+AMS reports the active functional per Jacob's-ladder rung in its density-functional
+block (`LDA:`, `Gradient Corrections:`, `Meta-GGA:`). The highest present rung is
+the functional in effect. A two-word gradient-correction entry names the exchange
+and correlation authors together (`Becke Perdew` = BP86).
+
+### CRYSTAL
+
+CRYSTAL names the exchange and correlation keywords separately (`BECKE`, `PZ`,
+`PBE`, `PWGGA`, …); the parser maps each keyword to its LibXC label(s) and lets
+the schema assemble the functional.
+
+### exciting
+
+exciting's INFO file gives an integer `xctype` code that the parser maps to LibXC
+labels; the XML output gives LibXC labels directly. The integer codes track a
+specific exciting/LibXC version (see *Known limitations*).
+
+### FHI-aims
+
+FHI-aims prints a descriptive control string per functional, which the parser
+maps to the corresponding standard name.
+
+### GPAW
+
+GPAW records a standard functional name directly and the parser passes it
+through unchanged.
+
+### octopus
+
+octopus prints the exchange and correlation parts as separate descriptive lines
+(`Slater exchange`, `Perdew & Zunger (Modified)`), which the parser maps to LibXC
+short-labels. The `XCFunctional` input variable is additionally an integer that
+is the *sum* of per-piece codes; when present it is decoded as a fallback to
+recover parts the descriptions did not name.
+
+### Quantum ESPRESSO
+
+QE prints XC either as a single name (`PBE`) or as its four DFT slot codes —
+exchange, correlation, gradient-exchange, gradient-correlation. `SLA PW PBX PBC`
+is Slater exchange + Perdew–Wang correlation + PBE gradient terms, i.e. PBE;
+`SLA PZ` is the Perdew–Zunger LDA. The parser recognises the common slot
+combinations and, for anything else, keeps the raw slot string so the reported
+XC is preserved rather than dropped.
+
 ### VASP
 
 VASP emits no functional name, so the canonical name is reconstructed from the
@@ -42,7 +98,7 @@ input tags in the order VASP itself resolves them: an explicit hybrid setup
 wins, then `METAGGA`, then `GGA`.
 
 The `GGA` and `METAGGA` tags are short two-letter codes (`PE` → PBE, `PS` →
-PBEsol, `RP` → RPBE, `RE` → revPBE, …). Two subtleties are worth stating:
+PBEsol, `RP` → RPBE, `RE` → revPBE, …). A few subtleties are worth stating:
 
 - **Hybrids** (`LHFCALC = .TRUE.`) are decided from `HFSCREEN`, `GGA` and `AEXX`
   together, not from the screening length alone. `HFSCREEN = 0.2`/`0.3` give the
@@ -60,58 +116,6 @@ PBEsol, `RP` → RPBE, `RE` → revPBE, …). Two subtleties are worth stating:
   parametrisation, `PZ81`). PBE is assumed only when neither `GGA` nor `LEXCH`
   is present.
 
-### ABINIT
-
-ABINIT identifies XC by the single integer `ixc`. A non-negative `ixc` selects a
-built-in preset (`1` = Teter93 LDA, `11` = PBE, `14` = revPBE, `15` = RPBE,
-`23` = Wu–Cohen, …), mapped through a small table. A **negative** `ixc` packs two
-LibXC functional ids positionally as `-(1000·id_x + id_c)` — for example
-`ixc = -101130` is LibXC `101` (`XC_GGA_X_PBE`) plus `130` (`XC_GGA_C_PBE`),
-i.e. PBE. The parser emits those ids as components and lets the schema registry
-resolve them, which also covers ids the local table does not list.
-
-### Quantum ESPRESSO
-
-QE prints XC either as a single name (`PBE`) or as its four DFT slot codes —
-exchange, correlation, gradient-exchange, gradient-correlation. `SLA PW PBX PBC`
-is Slater exchange + Perdew–Wang correlation + PBE gradient terms, i.e. PBE;
-`SLA PZ` is the Perdew–Zunger LDA. The parser recognises the common slot
-combinations and, for anything else, keeps the raw slot string so the reported
-XC is preserved rather than dropped.
-
-### octopus
-
-octopus prints the exchange and correlation parts as separate descriptive lines
-(`Slater exchange`, `Perdew & Zunger (Modified)`), which the parser maps to LibXC
-short-labels. The `XCFunctional` input variable is additionally an integer that
-is the *sum* of per-piece codes; when present it is decoded as a fallback to
-recover parts the descriptions did not name.
-
-### exciting
-
-exciting's INFO file gives an integer `xctype` code that the parser maps to LibXC
-labels; the XML output gives LibXC labels directly. The integer codes track a
-specific exciting/LibXC version (see *Known limitations*).
-
-### CRYSTAL
-
-CRYSTAL names the exchange and correlation keywords separately (`BECKE`, `PZ`,
-`PBE`, `PWGGA`, …); the parser maps each keyword to its LibXC label(s) and lets
-the schema assemble the functional.
-
-### AMS / ADF
-
-AMS reports the active functional per Jacob's-ladder rung in its density-functional
-block (`LDA:`, `Gradient Corrections:`, `Meta-GGA:`). The highest present rung is
-the functional in effect. A two-word gradient-correction entry names the exchange
-and correlation authors together (`Becke Perdew` = BP86).
-
-### GPAW and FHI-aims
-
-GPAW records a standard functional name directly and the parser passes it
-through unchanged. FHI-aims prints a descriptive control string per functional,
-which the parser maps to the corresponding standard name.
-
 ## Known limitations
 
 Some codes tie their XC identifiers to a specific LibXC (or code) release, so a
@@ -126,17 +130,17 @@ issues.
 The LibXC label taxonomy and each code's XC-input documentation:
 
 - LibXC functional list — <https://libxc.gitlab.io/functionals/>
+- ABINIT — the [`ixc`](https://docs.abinit.org/variables/basic/#ixc) input variable
+- AMS / ADF — [Density Functionals (XC)](https://www.scm.com/doc/ADF/Input/Density_Functional.html)
+- CRYSTAL — the `DFT`/`EXCHANGE`/`CORRELAT` keywords in the
+  [CRYSTAL23 user's manual](https://www.crystal.unito.it/include/manuals/crystal23.pdf)
+- exciting — the [`groundstate`/`xctype`](http://exciting-code.org/ref:groundstate) reference
+- FHI-aims — the `xc` keyword ([manual §3.3](https://fhi-aims.org/uploads/manual/Ch3/S3.html))
+- GPAW — [exchange–correlation functionals](https://gpaw.readthedocs.io/documentation/xc/functionals.html)
+- octopus — the [`XCFunctional`](https://octopus-code.org/documentation/13/variables/hamiltonian/xc/xcfunctional/) variable
+- Quantum ESPRESSO — [`input_dft`](https://www.quantum-espresso.org/Doc/INPUT_PW.html)
+  (the slot codes are defined in `Modules/funct.f90` / `XClib`)
 - VASP — [`GGA`](https://www.vasp.at/wiki/index.php/GGA),
   [`METAGGA`](https://www.vasp.at/wiki/index.php/METAGGA),
   [`LHFCALC`](https://www.vasp.at/wiki/index.php/LHFCALC) and the
   [list of hybrid functionals](https://www.vasp.at/wiki/index.php/List_of_hybrid_functionals)
-- ABINIT — the [`ixc`](https://docs.abinit.org/variables/basic/#ixc) input variable
-- Quantum ESPRESSO — [`input_dft`](https://www.quantum-espresso.org/Doc/INPUT_PW.html)
-  (the slot codes are defined in `Modules/funct.f90` / `XClib`)
-- octopus — the [`XCFunctional`](https://octopus-code.org/documentation/13/variables/hamiltonian/xc/xcfunctional/) variable
-- exciting — the [`groundstate`/`xctype`](http://exciting-code.org/ref:groundstate) reference
-- CRYSTAL — the `DFT`/`EXCHANGE`/`CORRELAT` keywords in the
-  [CRYSTAL23 user's manual](https://www.crystal.unito.it/include/manuals/crystal23.pdf)
-- AMS / ADF — [Density Functionals (XC)](https://www.scm.com/doc/ADF/Input/Density_Functional.html)
-- GPAW — [exchange–correlation functionals](https://gpaw.readthedocs.io/documentation/xc/functionals.html)
-- FHI-aims — the `xc` keyword ([manual §3.3](https://fhi-aims.org/uploads/manual/Ch3/S3.html))

--- a/docs/explanation/xc-functionals.md
+++ b/docs/explanation/xc-functionals.md
@@ -1,0 +1,119 @@
+# Exchange–correlation functionals
+
+## Overview
+
+Every DFT code records the exchange–correlation (XC) functional in its own way —
+an input tag, an integer code, or a human-readable line in the output — and only
+rarely as a single canonical name. The simulation parsers reduce that variety to
+one of two forms that the `nomad-simulations` schema understands, and leave the
+LibXC taxonomy (family, kind, and the derived Jacob's ladder rung) to the schema
+rather than reconstructing it per parser.
+
+A parser produces either:
+
+- a **canonical name** in `XCFunctional.functional_key` — used when the code
+  names the functional, or when its tags reduce cleanly to a standard name
+  (`PBE`, `HSE06`, `B3LYP5`, …). The schema's alias table
+  (`nomad_simulations/.../libxc/aliases.json`) expands the name into LibXC
+  components; or
+- **free-form components** in `XCFunctional.components` — used when the code
+  reports the exchange and correlation parts individually (as LibXC labels or
+  ids). The schema resolves each component from the LibXC registry, filling its
+  family and kind.
+
+The choice reflects what the code actually reports: a name where one exists, the
+raw parts otherwise. Either way the parser never hard-codes LibXC family/kind
+data. A component that the registry cannot resolve is retained and flagged
+`unidentified` instead of being dropped, so a functional's composition is never
+silently misrepresented as complete.
+
+This page explains the non-obvious conventions behind each code's mapping. It is
+deliberately not an exhaustive list of supported functionals — the maps in the
+parser sources are authoritative for that. It focuses on the setups where the
+code's XC specification is indirect or easy to misread.
+
+## How each code expresses XC
+
+### VASP
+
+VASP emits no functional name, so the canonical name is reconstructed from the
+input tags in the order VASP itself resolves them: an explicit hybrid setup
+wins, then `METAGGA`, then `GGA`.
+
+The `GGA` and `METAGGA` tags are short two-letter codes (`PE` → PBE, `PS` →
+PBEsol, `RP` → RPBE, `RE` → revPBE, …). Two subtleties are worth stating:
+
+- **Hybrids** (`LHFCALC = .TRUE.`) are decided from `HFSCREEN`, `GGA` and `AEXX`
+  together, not from the screening length alone. `HFSCREEN = 0.2`/`0.3` give the
+  screened HSE hybrids, but the base GGA sets the variant: a PBE base gives
+  HSE06/HSE03, whereas `GGA = PS` (PBEsol) gives **HSEsol**. The unscreened
+  global hybrid **PBE0** additionally requires that screening is off. `AEXX = 1`
+  with no DFT correlation is pure Hartree–Fock, not a DFT functional.
+- `GGA = B3` and `GGA = B5` are both B3LYP but with **different correlation** —
+  VWN3 (`B3` → `B3LYP`) versus VWN5 (`B5` → `B3LYP5`) — so they must not collapse
+  to one key.
+- When `GGA` is unset the effective functional is the **POTCAR default**, carried
+  by `LEXCH` (e.g. `LEXCH = CA` is the Ceperley–Alder LDA in the Perdew–Zunger
+  parametrisation, `PZ81`). PBE is assumed only when neither `GGA` nor `LEXCH`
+  is present.
+
+### ABINIT
+
+ABINIT identifies XC by the single integer `ixc`. A non-negative `ixc` selects a
+built-in preset (`1` = Teter93 LDA, `11` = PBE, `14` = revPBE, `15` = RPBE,
+`23` = Wu–Cohen, …), mapped through a small table. A **negative** `ixc` packs two
+LibXC functional ids positionally as `-(1000·id_x + id_c)` — for example
+`ixc = -101130` is LibXC `101` (`XC_GGA_X_PBE`) plus `130` (`XC_GGA_C_PBE`),
+i.e. PBE. The parser emits those ids as components and lets the schema registry
+resolve them, which also covers ids the local table does not list.
+
+### Quantum ESPRESSO
+
+QE prints XC either as a single name (`PBE`) or as its four DFT slot codes —
+exchange, correlation, gradient-exchange, gradient-correlation. `SLA PW PBX PBC`
+is Slater exchange + Perdew–Wang correlation + PBE gradient terms, i.e. PBE;
+`SLA PZ` is the Perdew–Zunger LDA. The parser recognises the common slot
+combinations and, for anything else, keeps the raw slot string so the reported
+XC is preserved rather than dropped.
+
+### octopus
+
+octopus prints the exchange and correlation parts as separate descriptive lines
+(`Slater exchange`, `Perdew & Zunger (Modified)`), which the parser maps to LibXC
+short-labels. The `XCFunctional` input variable is additionally an integer that
+is the *sum* of per-piece codes; when present it is decoded as a fallback to
+recover parts the descriptions did not name.
+
+### exciting
+
+exciting's INFO file gives an integer `xctype` code that the parser maps to LibXC
+labels; the XML output gives LibXC labels directly. The integer codes track a
+specific exciting/LibXC version (see *Known limitations*).
+
+### CRYSTAL
+
+CRYSTAL names the exchange and correlation keywords separately (`BECKE`, `PZ`,
+`PBE`, `PWGGA`, …); the parser maps each keyword to its LibXC label(s) and lets
+the schema assemble the functional.
+
+### AMS / ADF
+
+AMS reports the active functional per Jacob's-ladder rung in its density-functional
+block (`LDA:`, `Gradient Corrections:`, `Meta-GGA:`). The highest present rung is
+the functional in effect. A two-word gradient-correction entry names the exchange
+and correlation authors together (`Becke Perdew` = BP86).
+
+### GPAW and FHI-aims
+
+GPAW records a standard functional name directly and the parser passes it
+through unchanged. FHI-aims prints a descriptive control string per functional,
+which the parser maps to the corresponding standard name.
+
+## Known limitations
+
+Some codes tie their XC identifiers to a specific LibXC (or code) release, so a
+mapping that is correct for one version can drift in another — ABINIT's negative
+`ixc` LibXC ids and exciting's integer `xctype` codes are the main examples.
+Mappings should be cross-checked against the LibXC version the code is built with
+when in doubt. Open verification items are tracked in the parser repository's
+issues.

--- a/docs/explanation/xc-functionals.md
+++ b/docs/explanation/xc-functionals.md
@@ -48,8 +48,10 @@ PBEsol, `RP` → RPBE, `RE` → revPBE, …). Two subtleties are worth stating:
   together, not from the screening length alone. `HFSCREEN = 0.2`/`0.3` give the
   screened HSE hybrids, but the base GGA sets the variant: a PBE base gives
   HSE06/HSE03, whereas `GGA = PS` (PBEsol) gives **HSEsol**. The unscreened
-  global hybrid **PBE0** additionally requires that screening is off. `AEXX = 1`
-  with no DFT correlation is pure Hartree–Fock, not a DFT functional.
+  global hybrid **PBE0** additionally requires that screening is off, i.e.
+  `HFSCREEN = 0` — which is VASP's default, so it holds whether the tag is
+  explicitly zero or absent. `AEXX = 1` with no DFT correlation is pure
+  Hartree–Fock, not a DFT functional.
 - `GGA = B3` and `GGA = B5` are both B3LYP but with **different correlation** —
   VWN3 (`B3` → `B3LYP`) versus VWN5 (`B5` → `B3LYP5`) — so they must not collapse
   to one key.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,9 @@ nav:
       - VASP:
           - About: parsers/vasp/vasp_about.md
 
-  - Explanation: explanation/explanation.md
+  - Explanation:
+      - Overview: explanation/explanation.md
+      - Exchange-correlation functionals: explanation/xc-functionals.md
   - Reference: reference/references.md
 plugins:
   - search

--- a/src/nomad_simulation_parsers/parsers/abinit/parser.py
+++ b/src/nomad_simulation_parsers/parsers/abinit/parser.py
@@ -558,16 +558,24 @@ class MainfileParser(TextParser):
     def get_xc_functionals(self) -> list[dict[str, Any]]:
         ixc = self.get_input_var('ixc', 1, 1, scalar=True)
         if ixc >= 0:
-            xc_functionals = ABINIT_NATIVE_IXC.get(ixc, [])
-        else:
-            xc_functionals = []
-            functional1 = -ixc // 1000
-            if functional1 > 0:
-                xc_functionals.append(ABINIT_LIBXC_IXC.get(functional1))
-            functional2 = -ixc - (-ixc // 1000) * 1000
-            if functional2 > 0:
-                xc_functionals.append(ABINIT_LIBXC_IXC.get(functional2))
-        return xc_functionals
+            return [
+                {'unidentified': True}
+                if functional.get('XC_functional_name') == '?'
+                else functional
+                for functional in ABINIT_NATIVE_IXC.get(ixc, [])
+            ]
+        # LibXC path: the negative value packs two LibXC ids positionally. Id 0
+        # means the slot carries no functional; a non-zero id absent from the
+        # table is handed to the schema as a raw LibXC id to resolve or mark.
+        functional1 = -ixc // 1000
+        functional2 = -ixc - functional1 * 1000
+        components = []
+        for functional_id in (functional1, functional2):
+            if functional_id == 0:
+                continue
+            mapped = ABINIT_LIBXC_IXC.get(functional_id)
+            components.append(mapped if mapped else {'libxc_id': functional_id})
+        return components
 
     def get_bandstructures(
         self, eigenvalues: np.ndarray, occupations: np.ndarray

--- a/src/nomad_simulation_parsers/parsers/ams/parser.py
+++ b/src/nomad_simulation_parsers/parsers/ams/parser.py
@@ -46,16 +46,26 @@ class MainfileParser(TextParser):
     def logger(self):
         return LOGGER
 
-    def get_xc_functionals(self, source: dict[str, Any]) -> list[str]:
-        xc_functionals = []
-        for xc_type in ['LDA', 'GGA', 'MGGA']:
-            functionals = source.get(xc_type, '').split()
-            kind = ['XC'] if len(functionals) == 1 else ['X', 'C']
-            for n, functional in enumerate(functionals):
-                xc_functionals.append(
-                    f'{xc_type}_{kind[n]}_{functional.rstrip("x").rstrip("c").upper()}'
-                )
-        return xc_functionals
+    # AMS reports the active functional per rung ('LDA:', 'Gradient Corrections:',
+    # 'Meta-GGA:'); the highest present rung is the functional in effect. Map the
+    # AMS spelling to a standard functional name; the schema expands the name into
+    # LibXC components and derives `jacobs_ladder`. Unmapped strings pass through
+    # unchanged (a single token is usually already a standard name).
+    _ams_name_map = {
+        'Becke Perdew': 'BP86',
+        'Becke LYP': 'BLYP',
+        'BP': 'BP86',
+        'M06L': 'M06-L',
+        'M06-L': 'M06-L',
+    }
+
+    def get_functional_key(self, source: dict[str, Any]) -> str | None:
+        for rung in ('MGGA', 'GGA', 'LDA'):
+            value = (source.get(rung) or '').strip()
+            if not value:
+                continue
+            return self._ams_name_map.get(value, value)
+        return None
 
     def get_periodic_boundary_conditions(
         self, source: dict[str, Any] | Any

--- a/src/nomad_simulation_parsers/parsers/crystal/parser.py
+++ b/src/nomad_simulation_parsers/parsers/crystal/parser.py
@@ -45,7 +45,7 @@ class CrystalOutputParser(TextParser):
         'LDA': ['LDA_X'],
         'PWGGA': ['GGA_X_PW91', 'GGA_C_PW91'],
         'PZ': ['LDA_C_PZ'],
-        'WFN': ['LDA_C_VWN'],
+        'VWN': ['LDA_C_VWN'],
     }
 
     @property

--- a/src/nomad_simulation_parsers/parsers/exciting/parser.py
+++ b/src/nomad_simulation_parsers/parsers/exciting/parser.py
@@ -76,15 +76,15 @@ class InfoParser(TextParser):
 
     def get_xc_functionals(self, xc_type: int) -> list[dict[str, Any]]:
         xc_functional_map = {
-            2: ['LDA_C_PZ', 'LDA_X_PZ'],
-            3: ['LDA_C_PW', 'LDA_X_PZ'],
+            2: ['LDA_C_PZ', 'LDA_X'],
+            3: ['LDA_C_PW', 'LDA_X'],
             4: ['LDA_C_XALPHA'],
             5: ['LDA_C_VBH'],
             20: ['GGA_C_PBE', 'GGA_X_PBE'],
             21: ['GGA_C_PBE', 'GGA_X_PBE_R'],
             22: ['GGA_C_PBE_SOL', 'GGA_X_PBE_SOL'],
             26: ['GGA_C_PBE', 'GGA_X_WC'],
-            30: ['GGA_C_AM05', 'GGA_C_AM05'],
+            30: ['GGA_C_AM05', 'GGA_X_AM05'],
             300: ['GGA_C_BGCP', 'GGA_X_PBE'],
             406: ['HYB_GGA_XC_PBEH'],
             408: ['HYB_GGA_XC_HSE03'],

--- a/src/nomad_simulation_parsers/parsers/exciting/parser.py
+++ b/src/nomad_simulation_parsers/parsers/exciting/parser.py
@@ -495,10 +495,11 @@ class ExcitingArchiveWriter(ArchiveWriter):
                 info_parser.filepath = info_out
                 info_parser.convert(data_parser)
 
-        # read xc functionals from input.xml
+        # read xc functionals from input.xml only if INFO.OUT did not already
+        # populate them
         input_xml_files = (
             search_files('input.xml', maindir, re_pattern=mainbase)
-            if not self.archive.m_xpath('data.model_method[0].xc_functionals')
+            if not self.archive.m_xpath('data.model_method[0].xc.components')
             else []
         )
         if input_xml_files:

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -68,112 +68,39 @@ class FHIAimsOutMappingParser(TextMappingParser):
         'scgw': 'scGW',
     }
 
-    _xc_map = {
-        'Perdew-Wang parametrisation of Ceperley-Alder LDA': [
-            {'name': 'LDA_C_PW'},
-            {'name': 'LDA_X'},
-        ],
-        'Perdew-Zunger parametrisation of Ceperley-Alder LDA': [
-            {'name': 'LDA_C_PZ'},
-            {'name': 'LDA_X'},
-        ],
-        'VWN-LDA parametrisation of VWN5 form': [
-            {'name': 'LDA_C_VWN'},
-            {'name': 'LDA_X'},
-        ],
-        'VWN-LDA parametrisation of VWN-RPA form': [
-            {'name': 'LDA_C_VWN_RPA'},
-            {'name': 'LDA_X'},
-        ],
-        'AM05 gradient-corrected functionals': [
-            {'name': 'GGA_C_AM05'},
-            {'name': 'GGA_X_AM05'},
-        ],
-        'BLYP functional': [{'name': 'GGA_C_LYP'}, {'name': 'GGA_X_B88'}],
-        'PBE gradient-corrected functionals': [
-            {'name': 'GGA_C_PBE'},
-            {'name': 'GGA_X_PBE'},
-        ],
-        'PBEint gradient-corrected functional': [
-            {'name': 'GGA_C_PBEINT'},
-            {'name': 'GGA_X_PBEINT'},
-        ],
-        'PBEsol gradient-corrected functionals': [
-            {'name': 'GGA_C_PBE_SOL'},
-            {'name': 'GGA_X_PBE_SOL'},
-        ],
-        'RPBE gradient-corrected functionals': [
-            {'name': 'GGA_C_PBE'},
-            {'name': 'GGA_X_RPBE'},
-        ],
-        'revPBE gradient-corrected functionals': [
-            {'name': 'GGA_C_PBE'},
-            {'name': 'GGA_X_PBE_R'},
-        ],
-        'PW91 gradient-corrected functionals': [
-            {'name': 'GGA_C_PW91'},
-            {'name': 'GGA_X_PW91'},
-        ],
-        'M06-L gradient-corrected functionals': [
-            {'name': 'MGGA_C_M06_L'},
-            {'name': 'MGGA_X_M06_L'},
-        ],
-        'M11-L gradient-corrected functionals': [
-            {'name': 'MGGA_C_M11_L'},
-            {'name': 'MGGA_X_M11_L'},
-        ],
-        'TPSS gradient-corrected functionals': [
-            {'name': 'MGGA_C_TPSS'},
-            {'name': 'MGGA_X_TPSS'},
-        ],
-        'TPSSloc gradient-corrected functionals': [
-            {'name': 'MGGA_C_TPSSLOC'},
-            {'name': 'MGGA_X_TPSS'},
-        ],
-        'hybrid B3LYP functional': [{'name': 'HYB_GGA_XC_B3LYP5'}],
-        'Hartree-Fock': [{'name': 'HF_X'}],
-        'HSE': [{'name': 'HYB_GGA_XC_HSE03'}],
-        'HSE-functional': [{'name': 'HYB_GGA_XC_HSE06'}],
-        'hybrid-PBE0 functionals': [
-            {'name': 'GGA_C_PBE'},
-            {
-                'name': 'GGA_X_PBE',
-                'weight': lambda x: 0.75 if x is None else 1.0 - x,
-            },
-            {'name': 'HF_X', 'weight': lambda x: 0.25 if x is None else x},
-        ],
-        'hybrid-PBEsol0 functionals': [
-            {'name': 'GGA_C_PBE_SOL'},
-            {
-                'name': 'GGA_X_PBE_SOL',
-                'weight': lambda x: 0.75 if x is None else 1.0 - x,
-            },
-            {'name': 'HF_X', 'weight': lambda x: 0.25 if x is None else x},
-        ],
-        'Hybrid M06 gradient-corrected functionals': [
-            {'name': 'MGGA_C_M06'},
-            {'name': 'HYB_MGGA_X_M06'},
-        ],
-        'Hybrid M06-2X gradient-corrected functionals': [
-            {'name': 'MGGA_C_M06_2X'},
-            {'name': 'HYB_MGGA_X_M06'},
-        ],
-        'Hybrid M06-HF gradient-corrected functionals': [
-            {'name': 'MGGA_C_M06_HF'},
-            {'name': 'HYB_MGGA_X_M06'},
-        ],
-        'Hybrid M08-HX gradient-corrected functionals': [
-            {'name': 'MGGA_C_M08_HX'},
-            {'name': 'HYB_MGGA_X_M08_HX'},
-        ],
-        'Hybrid M08-SO gradient-corrected functionals': [
-            {'name': 'MGGA_C_M08_SO'},
-            {'name': 'HYB_MGGA_X_M08_SO'},
-        ],
-        'Hybrid M11 gradient-corrected functionals': [
-            {'name': 'MGGA_C_M11'},
-            {'name': 'HYB_MGGA_X_M11'},
-        ],
+    # FHI-aims XC control description -> standard functional name. The
+    # `nomad-simulations` schema expands the name into LibXC components
+    # (family/kind) and derives `jacobs_ladder`; the parser deliberately does
+    # not resolve LibXC labels itself. Names normalize case-insensitively, so
+    # the human-readable spelling used here resolves to the schema alias.
+    _xc_name_map = {
+        'Perdew-Wang parametrisation of Ceperley-Alder LDA': 'LDA',
+        'Perdew-Zunger parametrisation of Ceperley-Alder LDA': 'PZ81',
+        'VWN-LDA parametrisation of VWN5 form': 'VWN',
+        'VWN-LDA parametrisation of VWN-RPA form': 'VWN',
+        'AM05 gradient-corrected functionals': 'AM05',
+        'BLYP functional': 'BLYP',
+        'PBE gradient-corrected functionals': 'PBE',
+        'PBEint gradient-corrected functional': 'PBEint',
+        'PBEsol gradient-corrected functionals': 'PBEsol',
+        'RPBE gradient-corrected functionals': 'RPBE',
+        'revPBE gradient-corrected functionals': 'revPBE',
+        'PW91 gradient-corrected functionals': 'PW91',
+        'M06-L gradient-corrected functionals': 'M06-L',
+        'M11-L gradient-corrected functionals': 'M11-L',
+        'TPSS gradient-corrected functionals': 'TPSS',
+        'TPSSloc gradient-corrected functionals': 'TPSSloc',
+        'hybrid B3LYP functional': 'B3LYP',
+        'HSE': 'HSE03',
+        'HSE-functional': 'HSE06',
+        'hybrid-PBE0 functionals': 'PBE0',
+        'hybrid-PBEsol0 functionals': 'PBEsol0',
+        'Hybrid M06 gradient-corrected functionals': 'M06',
+        'Hybrid M06-2X gradient-corrected functionals': 'M06-2X',
+        'Hybrid M06-HF gradient-corrected functionals': 'M06-HF',
+        'Hybrid M08-HX gradient-corrected functionals': 'M08-HX',
+        'Hybrid M08-SO gradient-corrected functionals': 'M08-SO',
+        'Hybrid M11 gradient-corrected functionals': 'M11',
     }
 
     _section_names = ['full_scf', 'geometry_optimization', 'molecular_dynamics']
@@ -193,10 +120,11 @@ class FHIAimsOutMappingParser(TextMappingParser):
         files.sort()
         return files
 
-    def get_xc_functionals(self, xc: str) -> list[dict[str, Any]]:
-        return [
-            dict(name=functional.get('name')) for functional in self._xc_map.get(xc, [])
-        ]
+    def get_functional_key(self, xc: str) -> str | None:
+        """Standard functional name for this FHI-aims XC control string. The
+        schema expands the name into LibXC components (family/kind) and derives
+        `jacobs_ladder`; returns `None` for an unmapped string."""
+        return self._xc_name_map.get(xc)
 
     def get_periodic_boundary_conditions(self, source: dict[str, Any]) -> list[bool]:
         return [source.get('lattice_vectors') is not None] * 3

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -77,7 +77,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
         'Perdew-Wang parametrisation of Ceperley-Alder LDA': 'LDA',
         'Perdew-Zunger parametrisation of Ceperley-Alder LDA': 'PZ81',
         'VWN-LDA parametrisation of VWN5 form': 'VWN',
-        'VWN-LDA parametrisation of VWN-RPA form': 'VWN',
+        'VWN-LDA parametrisation of VWN-RPA form': 'VWN-RPA',
         'AM05 gradient-corrected functionals': 'AM05',
         'BLYP functional': 'BLYP',
         'PBE gradient-corrected functionals': 'PBE',

--- a/src/nomad_simulation_parsers/parsers/gpaw/gpw_parser.py
+++ b/src/nomad_simulation_parsers/parsers/gpaw/gpw_parser.py
@@ -304,22 +304,6 @@ class GPWFileParser(FileParser):
         'bohr': ureg.bohr,
         'femtosecond': ureg.fs,
     }
-    _xc_map = {
-        'LDA': ['LDA_X', 'LDA_C_PW'],
-        'PW91': ['GGA_X_PW91', 'GGA_C_PW91'],
-        'PBE': ['GGA_X_PBE', 'GGA_C_PBE'],
-        'PBEsol': ['GGA_X_PBE_SOL', 'GGA_C_PBE_SOL'],
-        'revPBE': ['GGA_X_PBE_R', 'GGA_C_PBE'],
-        'RPBE': ['GGA_X_RPBE', 'GGA_C_PBE'],
-        'BLYP': ['GGA_X_B88', 'GGA_C_LYP'],
-        'HCTH407': ['GGA_XC_HCTH_407'],
-        'WC': ['GGA_X_WC', 'GGA_C_PBE'],
-        'AM05': ['GGA_X_AM05', 'GGA_C_AM05'],
-        'M06-L': ['MGGA_X_M06_L', 'MGGA_C_M06_L'],
-        'TPSS': ['MGGA_X_TPSS', 'MGGA_C_TPSS'],
-        'revTPSS': ['MGGA_X_REVTPSS', 'MGGA_C_REVTPSS'],
-        'mBEEF': ['MGGA_X_MBEEF', 'GGA_C_PBE_SOL'],
-    }
     parser = GPWTarParser()
 
     def apply_unit(self, val: np.ndarray | float, unit: str) -> pint.Quantity:
@@ -363,7 +347,6 @@ class GPWFileParser(FileParser):
             bc.shape = [bc.size]
             pbc[: bc.size] = bc
         self._results['boundary_conditions'] = pbc
-        xc_functional = self.parser.get_parameter('xcfunctional')
-        self._results['xcfunctional'] = [
-            xc for xc in self._xc_map.get(xc_functional, [xc_functional])
-        ]
+        # GPAW records the standard functional name (e.g. 'PBE', 'revPBE');
+        # the schema expands it into LibXC components and derives `jacobs_ladder`.
+        self._results['xcfunctional'] = self.parser.get_parameter('xcfunctional')

--- a/src/nomad_simulation_parsers/parsers/octopus/parser.py
+++ b/src/nomad_simulation_parsers/parsers/octopus/parser.py
@@ -64,7 +64,7 @@ class OctopusMainfileParser(TextParser):
         'Lee and Parr Gaussian ansatz': ('lda_k_lp', 51),
         'Perdew, Burke & Ernzerhof exchange': ('gga_x_pbe', 101),
         'Perdew, Burke & Ernzerhof exchange (revised)': ('gga_x_pbe_r', 102),
-        'Becke 86 Xalfa,beta,gamma': ('gga_x_2d_b86', 128),
+        'Becke 86 Xalfa,beta,gamma': ('gga_x_b86', 103),
         'Herman et al original GGA': ('gga_x_herman', 104),
         'Becke 86 Xalfa,beta,gamma (with mod. grad. correction)': (
             'gga_x_b86_mgc',

--- a/src/nomad_simulation_parsers/parsers/octopus/parser.py
+++ b/src/nomad_simulation_parsers/parsers/octopus/parser.py
@@ -36,6 +36,7 @@ class OctopusMainfileParser(TextParser):
     # TODO resolve solely from the integer value
     _xc_functionals = {
         'Exchange': ('lda_x', 1),
+        'Slater exchange': ('lda_x', 1),
         'Wigner parametrization': ('lda_c_wigner', 2000),
         'Random Phase Approximation': ('lda_c_rpa', 3000),
         'Hedin & Lundqvist': ('lda_c_hl', 4000),

--- a/src/nomad_simulation_parsers/parsers/quantumespresso/common.py
+++ b/src/nomad_simulation_parsers/parsers/quantumespresso/common.py
@@ -331,7 +331,7 @@ general_quantities = [
     Quantity('mixing_scheme', r'number of iterations used\s*=\s*(\d+)\s*(.*)mixing'),
     Quantity(
         'xc_functional',
-        r'Exchange\-correlation\s*=\s*(.+)\s*(\([\d ]+\))',
+        r'Exchange\-correlation\s*=\s*(.+)',
         convert=False,
         flatten=False,
     ),

--- a/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
+++ b/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
@@ -123,7 +123,7 @@ class MainfileTextParser(TextParser):
         'SLA VWN': 'VWN',
         'SLA PW PBX PBC': 'PBE',
         'SLA PW PSX PSC': 'PBEsol',
-        'SLA PW RPB PBC': 'RPBE',
+        'SLA PW HHNX PBC': 'RPBE',
         'SLA PW REVX PBC': 'revPBE',
         'SLA PW WCX PBC': 'WC',
         'SLA PW GGX GGC': 'PW91',

--- a/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
+++ b/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
@@ -36,7 +36,6 @@ from nomad_simulation_parsers.parsers.utils.general import (
 )
 from nomad_simulation_parsers.schema_packages.quantumespresso import common
 
-from .common import libxc_shortcut, xc_functional_map
 from .file_parser import QuantumEspressoFileParser
 from .pwscf.file_parser import PWSCFFileParser
 
@@ -51,37 +50,6 @@ class QuantumEspressoMetainfoParser(MetainfoParser):
     @property
     def logger(self):
         return LOGGER
-
-
-class XCFunctionalParser:
-    @staticmethod
-    def gen_string(data: dict[str, Any], separator='+') -> str:
-        string = ''
-        for key in sorted(data.keys()):
-            val = data[key]
-            weight = val.get('XC_functional_weight', 1.0)
-            if string and weight > 0:
-                string += separator
-            if weight is not None:
-                string += f'{weight:.3f}'
-            string += val.get('XC_functional_name', '')
-        return string
-
-    @staticmethod
-    def filter_data(data: dict[str, dict[str, Any]]) -> dict[str, Any]:
-        out = dict()
-        tol = 0.01
-        for key, val in data.items():
-            val_copy = val.copy()
-            weight = val_copy.get('XC_functional_weight')
-            if weight is None or abs(weight) < tol:
-                continue
-            else:
-                if abs(weight - 1.0) < tol:
-                    del val_copy['XC_functional_weight']
-                val_copy.pop('exx_compute_weight', None)
-            out[key] = val_copy
-        return out
 
 
 def get_program_name_version(header: str) -> tuple[str, tuple[int]]:
@@ -144,80 +112,39 @@ class MainfileTextParser(TextParser):
             if key != 'energy_total' and val is not None
         ]
 
-    def get_xc_functionals(self, source: str) -> list[dict[str, Any]]:
-        # Keep legacy behavior for additional '(' while satisfying PLC0207.
-        numbers = source.split('(', maxsplit=2)[1].split(')', maxsplit=1)[0]
-        nval = (4, 10)
-        # handle different formatting
-        if len(numbers) == nval[0]:
-            # 4-digit format without spaces
-            numbers_split = re.findall(r'(\d)', numbers)
-        elif len(numbers) == nval[1]:
-            # 5-digit format with/without spaces
-            numbers_split = re.findall(r'[ \d]\d', numbers)
-        else:
-            # 6-digit with spaces
-            numbers_split = numbers.split()
+    # Quantum ESPRESSO prints the XC either as a single functional name ('PBE')
+    # or as the four DFT slot codes ('SLA PW PBX PBC'), optionally followed by
+    # the numeric slot codes in parentheses. Map the slot combination to a
+    # standard functional name; the schema expands it into LibXC components and
+    # derives `jacobs_ladder`.
+    _slot_combo_names = {
+        'SLA PZ': 'PZ81',
+        'SLA PW': 'LDA',
+        'SLA VWN': 'VWN',
+        'SLA PW PBX PBC': 'PBE',
+        'SLA PW PSX PSC': 'PBEsol',
+        'SLA PW RPB PBC': 'RPBE',
+        'SLA PW REVX PBC': 'revPBE',
+        'SLA PW WCX PBC': 'WC',
+        'SLA PW GGX GGC': 'PW91',
+        'SLA PW B88 P86': 'BP86',
+        'SLA LYP B88 BLYP': 'BLYP',
+    }
 
-        if not numbers_split:
-            self.logger.warning(
-                'Unknown XC functional format', data=dict(value=numbers)
-            )
-            return []
-
-        numbers_split = [int(n) for n in numbers_split]
-        # numbers should have six digits
-        numbers_split.extend([0] * (6 - len(numbers_split)))
-
-        # map numbers to values
-        xc_section_method = dict()
-        xc_terms = dict()
-        xc_terms_remove = dict()
-
-        def get_data(source: list[dict[str, Any]]) -> dict[str, Any]:
-            data = dict()
-            exx_fraction = self.get_header('x_qe_exact_exchange_fraction', 0.0)
-            for term in source:
-                term_copy = term.copy()
-                weight = term_copy.get('exx_compute_weight', 1.0)
-                term_copy['XC_functional_weight'] = (
-                    weight(exx_fraction) if not isinstance(weight, float) else weight
-                )
-                data.setdefault(term_copy.get('XC_functional_name', ''), term_copy)
-            return data
-
-        for i in range(6):
-            xc_component = xc_functional_map[i]
-            xc_number = numbers_split[i]
-            if xc_number >= len(xc_component) or xc_component[xc_number] is None:
-                continue
-            xc_section_method.update(
-                xc_component[xc_number].get('xc_section_method', {})
-            )
-            xc_terms.update(get_data(xc_component[xc_number].get('xc_terms', [])))
-            xc_terms_remove.update(
-                get_data(xc_component[xc_number].get('xc_terms_remove', []))
-            )
-
-        # remove terms
-        for key, val in xc_terms_remove.items():
-            weight = val.get('XC_functional_weight')
-            xc_terms.setdefault(key, val)
-            xc_terms[key]['XC_functional_weight'] *= -(weight or -1.0)
-
-        # filter data
-        xc_terms = XCFunctionalParser.filter_data(xc_terms)
-
-        xc_functional_str = XCFunctionalParser.gen_string(xc_terms)
-        if xc_functional_str in libxc_shortcut:
-            # override for libXC compliance
-            xc_terms = get_data(libxc_shortcut[xc_functional_str]['xc_terms'])
-            xc_terms = XCFunctionalParser.filter_data(xc_terms)
-            xc_functional_str = XCFunctionalParser.gen_string(xc_terms)
-        # TODO make use of this
-        xc_section_method['XC_functional'] = xc_functional_str
-
-        return [xc_terms[key] for key in sorted(xc_terms.keys())]
+    def get_functional_key(self, source: str) -> str | None:
+        if not source:
+            return None
+        # Drop the trailing numeric slot codes '( 1 4 3 4 0 0)' when present.
+        tokens = source.split('(', 1)[0].split()
+        if not tokens:
+            return None
+        if len(tokens) == 1:
+            return tokens[0]
+        combo = ' '.join(tokens)
+        name = self._slot_combo_names.get(combo)
+        if name is None:
+            self.logger.debug('unmapped QE XC slot combination', data=dict(value=combo))
+        return name
 
     def get_value(self, source: dict[str, Any], key: str = '', units: str = 'units'):
         key_split = key.rsplit('.', 1)

--- a/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
+++ b/src/nomad_simulation_parsers/parsers/quantumespresso/parser.py
@@ -143,7 +143,9 @@ class MainfileTextParser(TextParser):
         combo = ' '.join(tokens)
         name = self._slot_combo_names.get(combo)
         if name is None:
+            # preserve the raw slot combination so the reported XC is not dropped
             self.logger.debug('unmapped QE XC slot combination', data=dict(value=combo))
+            return combo
         return name
 
     def get_value(self, source: dict[str, Any], key: str = '', units: str = 'units'):

--- a/src/nomad_simulation_parsers/schema_packages/abinit.py
+++ b/src/nomad_simulation_parsers/schema_packages/abinit.py
@@ -71,6 +71,10 @@ class XCComponent(model_method.XCComponent):
     add_mapping_annotation(
         model_method.XCComponent.canonical_label, OUT_KEY, '.XC_functional_name'
     )
+    add_mapping_annotation(model_method.XCComponent.libxc_id, OUT_KEY, '.libxc_id')
+    add_mapping_annotation(
+        model_method.XCComponent.unidentified, OUT_KEY, '.unidentified'
+    )
 
 
 class XCFunctional(model_method.XCFunctional):

--- a/src/nomad_simulation_parsers/schema_packages/ams.py
+++ b/src/nomad_simulation_parsers/schema_packages/ams.py
@@ -45,22 +45,20 @@ class ModelSystem(model_system.ModelSystem):
     ).update(dict(ams_out=Mapper(mapper='.lattice_vectors')))
 
 
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper='.@')))
+class DFT(model_method.DFT):
+    # Materialize the `xc` subsection so its child `functional_key` mapper runs.
+    add_mapping_annotation(model_method.DFT.xc, OUT_KEY, '.@')
 
 
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(
-#         dict(
-#             out=Mapper(
-#                 mapper=('get_xc_functionals', ['.model_parameters.dft_potential'])
-#             )
-#         )
-#     )
+class XCFunctional(model_method.XCFunctional):
+    # Set `functional_key` to the standard functional name from the AMS DFT
+    # potential block; the schema expands it into components (family/kind) and
+    # derives `jacobs_ladder`.
+    add_mapping_annotation(
+        model_method.XCFunctional.functional_key,
+        OUT_KEY,
+        ('get_functional_key', ['.model_parameters.dft_potential']),
+    )
 
 
 class TotalEnergy(outputs.TotalEnergy):

--- a/src/nomad_simulation_parsers/schema_packages/crystal.py
+++ b/src/nomad_simulation_parsers/schema_packages/crystal.py
@@ -49,7 +49,7 @@ class XCComponent(model_method.XCComponent):
 
 class XCFunctional(model_method.XCFunctional):
     add_mapping_annotation(
-        model_method.XCFunctional.components, OUT_KEY, ('get_xc_functionals', ['.dft'])
+        model_method.XCFunctional.components, OUT_KEY, ('get_xc_functionals', ['.@'])
     )
 
 

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -93,18 +93,19 @@ class Program(general.Program):
 
 class DFT(model_method.DFT):
     add_mapping_annotation(numerical_settings.KSpace.m_def, TEXT_KEY, '.@')
+    # Materialize the `xc` subsection so its child `functional_key` mapper runs.
+    add_mapping_annotation(model_method.DFT.xc, TEXT_KEY, '.@')
 
 
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(text=Mapper(mapper=('get_xc_functionals', ['.controlInOut_xc']))))
-
-
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(text=Mapper(mapper='.name')))
+class XCFunctional(model_method.XCFunctional):
+    # Set `functional_key` to the standard functional name from the FHI-aims XC
+    # control string; the schema expands the name into components (family/kind)
+    # and derives `jacobs_ladder`.
+    add_mapping_annotation(
+        model_method.XCFunctional.functional_key,
+        TEXT_KEY,
+        ('get_functional_key', ['.controlInOut_xc']),
+    )
 
 
 class GW(model_method.GW):

--- a/src/nomad_simulation_parsers/schema_packages/gpaw.py
+++ b/src/nomad_simulation_parsers/schema_packages/gpaw.py
@@ -40,20 +40,17 @@ class ModelSystem(model_system.ModelSystem):
     add_mapping_annotation(model_system.AtomsState.m_def, GPW_KEY, '.labels')
 
 
-class XCComponent(model_method.XCComponent):
-    add_mapping_annotation(model_method.XCComponent.canonical_label, GPW_KEY, '.@')
+class DFT(model_method.DFT):
+    # Materialize the `xc` subsection so its child `functional_key` mapper runs.
+    add_mapping_annotation(model_method.DFT.xc, GPW_KEY, '.@')
 
 
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(gpw=Mapper(mapper='.@')))
-
-
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(gpw=Mapper(mapper='.xcfunctional')))
+class XCFunctional(model_method.XCFunctional):
+    # GPAW stores the standard functional name directly; the schema expands it
+    # into components (family/kind) and derives `jacobs_ladder`.
+    add_mapping_annotation(
+        model_method.XCFunctional.functional_key, GPW_KEY, '.xcfunctional'
+    )
 
 
 class TotalEnergy(outputs.TotalEnergy):

--- a/src/nomad_simulation_parsers/schema_packages/octopus.py
+++ b/src/nomad_simulation_parsers/schema_packages/octopus.py
@@ -23,16 +23,16 @@ class XCComponent(model_method.XCComponent):
     add_mapping_annotation(model_method.XCComponent.canonical_label, OUT_KEY, '.@')
 
 
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper='.@')))
+class XCFunctional(model_method.XCFunctional):
+    add_mapping_annotation(
+        model_method.XCFunctional.components,
+        OUT_KEY,
+        ('get_xc_functionals', ['.theory_level']),
+    )
 
 
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper=('get_xc_functionals', ['.theory_level']))))
+class DFT(model_method.DFT):
+    add_mapping_annotation(model_method.DFT.xc, OUT_KEY, '.@')
 
 
 class ModelSystem(model_system.ModelSystem):

--- a/src/nomad_simulation_parsers/schema_packages/quantumespresso/common.py
+++ b/src/nomad_simulation_parsers/schema_packages/quantumespresso/common.py
@@ -31,22 +31,24 @@ class Program(general.Program):
     )
 
 
-class XCComponent(model_method.XCComponent):
+class DFT(model_method.DFT):
+    # Materialize the `xc` subsection so its child `functional_key` mapper runs.
+    add_mapping_annotation(model_method.DFT.xc, OUT_KEY, '.@')
+    add_mapping_annotation(model_method.DFT.xc, XML_KEY, '.@')
+
+
+class XCFunctional(model_method.XCFunctional):
+    # The output prints a functional name or the four DFT slot codes; the XML
+    # carries a clean functional name. Both resolve to a standard name that the
+    # schema expands into components (family/kind) and `jacobs_ladder`.
     add_mapping_annotation(
-        model_method.XCComponent.canonical_label, OUT_KEY, '.XC_functional_name'
+        model_method.XCFunctional.functional_key,
+        OUT_KEY,
+        ('get_functional_key', ['.xc_functional']),
     )
-
-
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper='.XC_functional_name')))
-
-
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(out=Mapper(mapper=('get_xc_functionals', ['.xc_functional']))))
+    add_mapping_annotation(
+        model_method.XCFunctional.functional_key, XML_KEY, '.dft.functional'
+    )
 
 
 class AtomsState(model_system.AtomsState):


### PR DESCRIPTION
## Purpose

Extends the VASP exchange–correlation and Jacob's ladder work (#196) to the
other DFT parsers, so each populates `DFT.xc` and lets the schema derive
`jacobs_ladder`. Parsers hand the schema a standard functional name where the
code names the functional, or the raw LibXC components where the code reports
the individual exchange/correlation parts — never doing LibXC taxonomy lookups
themselves.

## Scope

**Included** — XC parsing for eight parsers, one commit each:

| Parser | Representation | add / rework |
|---|---|---|
| fhiaims | `functional_key` (name from XC control string) | add |
| gpaw | `functional_key` (native name) | add |
| ams | `functional_key` (name of the highest active rung) | add |
| quantumespresso | `functional_key` (printed name or four-slot code; XML `<functional>`) | add |
| octopus | free-form components (LibXC labels) | add |
| abinit | free-form components (LibXC labels / ids from `ixc`) | rework |
| crystal | free-form components (LibXC labels) | rework |
| exciting | free-form components (LibXC label / INFO id) | rework |

Name-path parsers set `XCFunctional.functional_key`; the schema expands it via
the existing alias table. Component-path parsers populate `XCFunctional.components`
with raw LibXC labels/ids; the schema resolves the taxonomy.

**Out of scope**

- VASP itself (this builds on #196).
- Non-DFT parsers (gromacs, lammps, h5md, lobster, phonopy, wannier90, yambo).

## Context & Links

- Targets #196 — same `functional_key` / component pattern, extended.
- Depends on nomad-simulations PR #440 (free-form component resolution + the
  `unidentified` marker) for the four component-path parsers. That PR should
  merge first.

## Reviewer Notes

- Representation per parser reflects what the code actually reports: a name when
  the code names the functional, raw LibXC parts (label or id) when it does not.
  This keeps LibXC knowledge in the schema, not the parsers.
- Fixes surfaced while wiring these up:
  - octopus dropped the exchange component because its table keyed only the
    legacy `Exchange` spelling, not the `Slater exchange` the code prints.
  - crystal emitted no method at all: the `components` transformer sourced
    `.dft` while `DFT` is rooted at `.dft`, resolving to `.dft.dft` (nothing),
    so the empty `DFT` was pruned. Now sourced from `.@`.
  - exciting always re-read `input.xml` because its guard tested the removed
    `xc_functionals` field; repointed to `xc.components`.
  - abinit keeps every reported component: a `?` slot becomes an `unidentified`
    placeholder and an out-of-table LibXC id is handed to the schema as a raw
    id, rather than dropping it.

## Status

- [x] Ready for review (pending #440)

## Breaking Changes

- [x] None.

## Dependencies / Blockers

- [x] nomad-simulations PR #440 — required by the four component-path parsers.

## Testing / Validation

- [x] Unit tests — each parser's suite passes.
- [x] Manual testing — sample-parsed a fixture per parser; confirmed
  `functional_key`/`components` resolve to `family`/`kind` and the expected
  `jacobs_ladder` rung.
