### PR TITLE
topology and PBC populate frame 0 only in model_system

### DIFF
--- a/src/nomad_simulation_parsers/parsers/gromacs/parser.py
+++ b/src/nomad_simulation_parsers/parsers/gromacs/parser.py
@@ -193,7 +193,8 @@ class GromacsLogParser(TextParser, GromacsThermodynamicsParser):
         pbc = [
             k in self.data.get('input_parameters', {}).get('pbc', 'xyz') for k in 'xyz'
         ]
-        return [dict(pbc=pbc) for _ in self._trajectory_steps_sampled]
+        n = len(self._trajectory_steps_sampled)
+        return [dict(pbc=pbc)] + [{}] * (n - 1) if n > 0 else []
 
     def get_outputs(self) -> list[dict[str, Any]]:
         data = {}
@@ -858,24 +859,24 @@ class GromacsMDAnalysisParser(MappingParser):
         return result
 
     def get_configurations(self) -> list[dict[str, Any]]:
-        # Labels, n_particles and bond_list are frame-independent; compute once.
-        labels = self.get_particle_parameters()
         n_particles = self.data_object.get_n_atoms(0)
         bond_list = self.get_bond_list()
 
         configurations = []
         for n, _ in enumerate(self._trajectory_steps_sampled):
-            # get_frame_data performs a single trajectory seek for all per-frame data.
             frame_data = self.data_object.get_frame_data(n)
-            config = dict(
-                n_particles=n_particles,
-                labels=labels,
+            config: dict[str, Any] = dict(
                 positions=frame_data['positions'],
                 velocities=frame_data['velocities'],
-                lattice_vectors=frame_data['lattice_vectors'],
             )
-            if n == 0 and bond_list is not None:
-                config['bond_list'] = bond_list
+            if n == 0:
+                config['n_particles'] = n_particles
+                config['labels'] = self.get_particle_parameters()
+                lv = frame_data.get('lattice_vectors')
+                if lv is not None:
+                    config['lattice_vectors'] = lv
+                if bond_list is not None:
+                    config['bond_list'] = bond_list
             configurations.append(config)
         return configurations
 

--- a/tests/parsers/test_gromacs_parser.py
+++ b/tests/parsers/test_gromacs_parser.py
@@ -85,11 +85,16 @@ def test_mdanalysis_get_configurations_returns_positions_and_labels(
 
     assert isinstance(configs, list)
     assert len(configs) == 2
+    # per-frame data present in every frame
     assert np.allclose(configs[0]['positions'], positions[0])
     assert np.allclose(configs[1]['positions'], positions[1])
+    # topology only on frame 0
     assert np.allclose(configs[0]['lattice_vectors'], lattices[0])
-    # labels are produced by get_atom_labels; ensure key exists
     assert 'labels' in configs[0]
+    assert 'n_particles' in configs[0]
+    assert 'lattice_vectors' not in configs[1]
+    assert 'labels' not in configs[1]
+    assert 'n_particles' not in configs[1]
 
 
 def test_metainfo_convert_populates_simulation_model_system(simple_mdanalysis_parser):
@@ -130,8 +135,10 @@ def test_logparser_get_configurations_pbc_and_sampling():
     configs = lp.get_configurations()
 
     assert len(configs) == 3
-    assert all('pbc' in c for c in configs)
+    assert 'pbc' in configs[0]
     assert configs[0]['pbc'] == [True, True, False]
+    assert configs[1] == {}
+    assert configs[2] == {}
 
 
 def test_edrparser_get_energies_from_data():


### PR DESCRIPTION
Positions and velocities are updated per frame; n_particles, lattice_vectors, labels (AtomsState) and bond_list are written only to the first configuration dict, so MappingParser does not repeat frame-invariant topology for every trajectory snapshot.

GromacsLogParser.get_configurations likewise emits PBC only for the first frame and returns empty dicts for subsequent ones.