### PR TITLE
Adopt the split SCF density-convergence quantities and `DensityConvergenceTarget` in exciting/fhiaims

### DIFF
--- a/src/nomad_simulation_parsers/parsers/exciting/parser.py
+++ b/src/nomad_simulation_parsers/parsers/exciting/parser.py
@@ -14,7 +14,7 @@ from nomad_file_parser.mapping_parser import (
 )
 from nomad_simulations.schema_packages.general import Simulation
 from nomad_simulations.schema_packages.workflow.general import (
-    ChargeConvergenceTarget,
+    DensityConvergenceTarget,
     EnergyConvergenceTarget,
     ForceConvergenceTarget,
     PotentialConvergenceTarget,
@@ -52,8 +52,9 @@ convergence_threshold_mapping = {
         'threshold_type': 'absolute',
     },
     'x_exciting_charge_convergence': {
-        'class': ChargeConvergenceTarget,
+        'class': DensityConvergenceTarget,
         'threshold_type': 'absolute',
+        'type': 'charge_abs',
     },
     'x_exciting_IBS_force_convergence': {
         'class': ForceConvergenceTarget,
@@ -219,10 +220,13 @@ class InfoParser(TextParser):
             # target Quantity units.
             threshold_value = quantity[1]
 
-            target = info_['class'](
-                threshold=threshold_value,
-                threshold_type=info_['threshold_type'],
-            )
+            target_kwargs = {
+                'threshold': threshold_value,
+                'threshold_type': info_['threshold_type'],
+            }
+            if 'type' in info_:
+                target_kwargs['type'] = info_['type']
+            target = info_['class'](**target_kwargs)
             convergence_targets.append(target)
         return convergence_targets
 
@@ -267,7 +271,7 @@ class InfoParser(TextParser):
             [
                 'delta_energies_total',
                 'delta_potential_rms',
-                'delta_density_rms',
+                'delta_charge_abs',
                 'delta_force_abs',
             ],
             [delta_energies, delta_potential, delta_charge, delta_force],

--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -340,7 +340,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
             return {}
 
         delta_energies_total = []
-        delta_density_rms = []
+        delta_charge_abs = []
         durations = []
         delta_sum_eigenvalues = []
 
@@ -352,7 +352,7 @@ class FHIAimsOutMappingParser(TextMappingParser):
 
             delta_density = convergence.get('Change of charge density')
             if delta_density is not None:
-                delta_density_rms.append(
+                delta_charge_abs.append(
                     abs(float(delta_density)) * ureg.elementary_charge
                 )
 
@@ -367,8 +367,8 @@ class FHIAimsOutMappingParser(TextMappingParser):
         scf_steps = {}
         if delta_energies_total:
             scf_steps['delta_energies_total'] = delta_energies_total
-        if delta_density_rms:
-            scf_steps['delta_density_rms'] = delta_density_rms
+        if delta_charge_abs:
+            scf_steps['delta_charge_abs'] = delta_charge_abs
         if len(durations) == len(scf_iterations):
             scf_steps['durations'] = durations
         if delta_sum_eigenvalues:

--- a/src/nomad_simulation_parsers/schema_packages/exciting.py
+++ b/src/nomad_simulation_parsers/schema_packages/exciting.py
@@ -218,7 +218,7 @@ add_mapping_annotations(
     (outputs.SCFSteps.energies_total, INFO_KEY, '.energies_total'),
     (outputs.SCFSteps.delta_energies_total, INFO_KEY, '.delta_energies_total'),
     (outputs.SCFSteps.delta_potential_rms, INFO_KEY, '.delta_potential_rms'),
-    (outputs.SCFSteps.delta_density_rms, INFO_KEY, '.delta_density_rms'),
+    (outputs.SCFSteps.delta_charge_abs, INFO_KEY, '.delta_charge_abs'),
     (outputs.SCFSteps.delta_force_abs, INFO_KEY, '.delta_force_abs'),
 )
 

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -198,7 +198,7 @@ class SCFSteps(outputs.SCFSteps):
         outputs.SCFSteps.delta_energies_total, TEXT_KEY, '.delta_energies_total'
     )
     add_mapping_annotation(
-        outputs.SCFSteps.delta_density_rms, TEXT_KEY, '.delta_density_rms'
+        outputs.SCFSteps.delta_charge_abs, TEXT_KEY, '.delta_charge_abs'
     )
     add_mapping_annotation(outputs.SCFSteps.durations, TEXT_KEY, '.durations')
     add_mapping_annotation(

--- a/tests/parsers/test_exciting_parser.py
+++ b/tests/parsers/test_exciting_parser.py
@@ -27,7 +27,7 @@ CASES = {
                     'threshold_type': 'absolute',
                     'threshold': (4.3597447222071695e-24, 'joule'),
                 },
-                'ChargeConvergenceTarget': {
+                'DensityConvergenceTarget': {
                     'threshold_type': 'absolute',
                     'threshold': (1e-05, 'coulomb'),
                 },
@@ -39,7 +39,7 @@ CASES = {
                 'last': (4.3213092127361915e-25, 'joule'),
             },
             'delta_potential_rms': {'len': 10, 'last': (1.41636334713761e-26, 'joule')},
-            'delta_density_rms': {'len': 10, 'last': (2.35501e-09, 'coulomb')},
+            'delta_charge_abs': {'len': 10, 'last': (2.35501e-09, 'coulomb')},
             'delta_force_abs': None,
         },
     },
@@ -61,7 +61,7 @@ CASES = {
                     'threshold_type': 'absolute',
                     'threshold': (4.35974472220717e-22, 'joule'),
                 },
-                'ChargeConvergenceTarget': {
+                'DensityConvergenceTarget': {
                     'threshold_type': 'absolute',
                     'threshold': (1e-05, 'coulomb'),
                 },
@@ -77,7 +77,7 @@ CASES = {
                 'last': (1.4699010123263138e-23, 'joule'),
             },
             'delta_potential_rms': {'len': 24, 'last': (2.13237730209986e-25, 'joule')},
-            'delta_density_rms': {
+            'delta_charge_abs': {
                 'len': 24,
                 'last': (4.16073e-08, 'coulomb'),
             },

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -56,13 +56,13 @@ def test_scf_steps_quantities():
         scf_steps = output.scf_steps
         assert scf_steps is not None
         assert len(scf_steps.delta_energies_total) == n_scf
-        assert len(scf_steps.delta_density_rms) == n_scf
+        assert len(scf_steps.delta_charge_abs) == n_scf
         assert len(scf_steps.durations) == n_scf
 
     # Explicitly check last SCF-step deltas in first geometry-optimization step
     first_steps = outputs[1].scf_steps
     assert first_steps.delta_energies_total[-1].to('eV').magnitude == approx(7.477e-09)
-    assert first_steps.delta_density_rms[-1].to('coulomb').magnitude == approx(
+    assert first_steps.delta_charge_abs[-1].to('coulomb').magnitude == approx(
         6.375e-08 * 1.602176634e-19
     )
 


### PR DESCRIPTION
## Purpose

The schema PR removes `SCFSteps.delta_density_rms` and `ChargeConvergenceTarget` in favour of definition-specific density-convergence quantities and a `DensityConvergenceTarget` with a `type` selector. The exciting and fhiaims parsers referenced the removed names at module load, so they must be adapted for the schema to remain importable and the parsers to keep working.

## Scope

**Included**

- exciting and fhiaims: `SCFSteps.delta_density_rms` mapping to `delta_charge_abs` (both emit a `coulomb`-tagged charge residual, so numeric behavior is preserved).
- exciting: the SCF charge-convergence target `ChargeConvergenceTarget` to `DensityConvergenceTarget(type='charge_abs')`.
- Updated the corresponding parser tests (`test_exciting_parser.py`, `test_fhiaims_parser.py`).

**Out of scope**

- Adopting the other new quantities where a code actually reports them: VASP `delta_charge_density_rms`, QE `energy_error_estimate`, ABINIT `delta_potential_rms`.
- Refining exciting's "charge distance" from `charge_abs` to the more accurate `charge_relative` (it is normalized/dimensionless); kept conservative here to preserve current numeric behavior.

## Context & Links

- Depends on the schema change: FAIRmat-NFDI/nomad-simulations#457 -- the new `SCFSteps` quantities and `DensityConvergenceTarget` land there. This PR must merge together with (or immediately after) it.

## Reviewer Notes

- No schema is defined here; this is purely parser adaptation to the breaking schema change.
- A pre-existing orphaned snapshot `tests/parsers/__snapshots__/test_migration_snapshots.ambr` still holds the old field name; it has no matching test file and is not run by CI, so it is left untouched.

## Status

- [ ] Draft / In progress
- [x] Ready for review
- [ ] Blocked (explain):

## Breaking Changes

- [x] None here directly, but this PR is coupled to a breaking schema change (see dependency).

## Dependencies / Blockers

- [x] Requires FAIRmat-NFDI/nomad-simulations#457.

## Testing / Validation

- [x] `test_exciting_parser.py` (15 passed / 2 skipped) and `test_fhiaims_parser.py` (6 passed); full parser suite green (212 passed / 9 skipped at last full run).
