### PR TITLE
Route FHI-aims SCF eigenvalues to `electronic_eigenvalues` (fixes nomad-simulations#462)

### DIFF
--- a/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
+++ b/src/nomad_simulation_parsers/parsers/fhiaims/parser.py
@@ -194,7 +194,9 @@ class FHIAimsOutMappingParser(TextMappingParser):
     ) -> list[dict[str, Any]]:
         n_spin = params.get('Number of spin channels', 1)
         eigenvalues = []
-        for data in source:
+        # Only the last "Writing Kohn-Sham eigenvalues" block holds the converged
+        # eigenvalues; earlier blocks are intermediate SCF snapshots.
+        for data in (source or [])[-1:]:
             kpts = data.get('kpoints', [np.zeros(3)] * n_spin)
             kpts = np.reshape(kpts, (len(kpts) // n_spin, n_spin, 3))
             kpts = np.transpose(kpts, axes=(1, 0, 2))[0]
@@ -211,8 +213,9 @@ class FHIAimsOutMappingParser(TextMappingParser):
                         nbands=n_eigs,
                         npoints=n_kpts,
                         points=kpts,
-                        occupations=occs_eigs[0][spin],
-                        eigenvalues=occs_eigs[1][spin],
+                        occupation=occs_eigs[0][spin],
+                        value=occs_eigs[1][spin] * ureg.hartree,
+                        spin_channel=spin if n_spin > 1 else None,
                     )
                 )
         return eigenvalues
@@ -221,15 +224,15 @@ class FHIAimsOutMappingParser(TextMappingParser):
         self, source: list[dict[str, Any]], params: dict[str, Any]
     ) -> list[dict[str, Any]]:
         band_structures = []
-        for spin_channel, eig in enumerate(self.get_eigenvalues(source, params)):
-            values = eig.get('eigenvalues')
+        for eig in self.get_eigenvalues(source, params):
+            values = eig.get('value')
             if values is None:
                 continue
             band_structures.append(
                 dict(
                     value=values,
-                    occupation=eig.get('occupations'),
-                    spin_channel=spin_channel,
+                    occupation=eig.get('occupation'),
+                    spin_channel=eig.get('spin_channel'),
                 )
             )
         return band_structures

--- a/src/nomad_simulation_parsers/schema_packages/fhiaims.py
+++ b/src/nomad_simulation_parsers/schema_packages/fhiaims.py
@@ -129,18 +129,6 @@ class XCFunctional(model_method.XCFunctional):
     )
 
 
-# class DFT(model_method.DFT):
-#     model_method.DFT.xc_functionals.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(text=Mapper(mapper=('get_xc_functionals', ['.controlInOut_xc']))))
-
-
-# class XCFunctional(model_method.XCFunctional):
-#     model_method.XCFunctional.libxc_name.m_annotations.setdefault(
-#         MAPPING_ANNOTATION_KEY, {}
-#     ).update(dict(text=Mapper(mapper='.name')))
-
-
 class GW(model_method.GW):
     add_mapping_annotation(
         model_method.GW.type, TEXT_GW_KEY, ('get_gw_flag', ['.gw_flag'])
@@ -176,18 +164,6 @@ class AtomsState(model_system.AtomsState):
 class Outputs(outputs.Outputs):
     add_mapping_annotation(
         outputs.Outputs.total_energies, TEXT_KEY, ('get_energies', ['.@'])
-    )
-    outputs.Outputs.total_forces.m_annotations.setdefault(
-        MAPPING_ANNOTATION_KEY, {}
-    ).update(dict(text=Mapper(mapper=('get_forces', ['.@']))))
-    outputs.Outputs.electronic_eigenvalues.m_annotations.setdefault(
-        MAPPING_ANNOTATION_KEY, {}
-    ).update(
-        dict(
-            text=Mapper(
-                mapper=('get_eigenvalues', ['.eigenvalues', 'array_size_parameters'])
-            )
-        )
     )
     add_mapping_annotation(
         outputs.Outputs.total_forces, TEXT_KEY, ('get_forces', ['.@'])
@@ -254,19 +230,11 @@ class TotalForce(properties.forces.TotalForce):
     add_mapping_annotation(properties.forces.TotalForce.value, TEXT_KEY, '.forces')
 
 
-# TODO: check whether this section is k-dependent
-class ElectronicEigenvalues(properties.ElectronicEigenvalues):
-    # properties.ElectronicEigenvalues.n_bands.m_annotations.setdefault(
-    #     MAPPING_ANNOTATION_KEY, {}
-    # ).update(dict(text=Mapper(mapper='.nbands')))
-    properties.ElectronicEigenvalues.value.m_annotations.setdefault(
-        MAPPING_ANNOTATION_KEY, {}
-    ).update(dict(text=Mapper(mapper='.eigenvalues')))
-    properties.ElectronicEigenvalues.occupation.m_annotations.setdefault(
-        MAPPING_ANNOTATION_KEY, {}
-    ).update(dict(text=Mapper(mapper='.occupations')))
-
-
+# `value`, `occupation` and `spin_channel` are inherited (shared Quantity objects)
+# from `ElectronicEigenvalues`, so annotating them here also drives the
+# `electronic_eigenvalues` sections. Both are populated from the same converged
+# Kohn-Sham eigenvalues (`get_eigenvalues` / `get_band_structures`), which emit
+# matching `value`/`occupation`/`spin_channel` keys.
 class ElectronicBandStructure(properties.ElectronicBandStructure):
     add_mapping_annotation(properties.ElectronicBandStructure.value, TEXT_KEY, '.value')
     add_mapping_annotation(

--- a/tests/parsers/test_fhiaims_parser.py
+++ b/tests/parsers/test_fhiaims_parser.py
@@ -175,3 +175,36 @@ def test_scf_convergence_criteria():
     assert eigenvalues_criterion is not None
     assert eigenvalues_criterion.threshold_change.magnitude == approx(1.0e-3)
     assert str(eigenvalues_criterion.threshold_change.units) == 'electron_volt'
+
+
+def test_scf_eigenvalues_and_band_structures():
+    """
+    Regression for FHIaims #462: the SCF Kohn-Sham eigenvalue prints populate BOTH
+    `electronic_eigenvalues` and `electronic_band_structures`, as a single converged
+    section per output, correctly shaped (Hartree->eV, `spin_channel` unset for
+    spin-unpolarized) rather than the earlier malformed multi-section output with a
+    bogus `spin_channel` and raw (unconverted) values.
+    """
+    parser = FHIAimsParser()
+    archive = EntryArchive()
+    parser.parse('tests/data/fhiaims/Si_geomopt/out.out', archive, LOGGER)
+
+    outputs = archive.data.outputs
+    assert outputs is not None and len(outputs) == 5
+
+    for output in outputs:
+        eigenvalues = output.electronic_eigenvalues
+        band_structures = output.electronic_band_structures
+        # exactly one converged section of each per output (spin-unpolarized Si)
+        assert len(eigenvalues) == 1
+        assert len(band_structures) == 1
+
+        for section in (eigenvalues[0], band_structures[0]):
+            # `spin_channel` unset so `occupation` is read on the 0-2 scale
+            assert section.spin_channel is None
+            assert section.value.shape == section.occupation.shape
+            # FHI-aims default prints only the Gamma point
+            assert section.value.shape[0] == 1
+            # Hartree->Joule conversion applied (state 1 ~ -1774 eV, not ~1e20)
+            assert section.value.to('eV').magnitude[0][0] == approx(-1774.0, abs=2.0)
+            assert section.occupation[0][0] == approx(2.0)


### PR DESCRIPTION
## Purpose

The FHI-aims parser turned every SCF "Writing Kohn-Sham eigenvalues" print into an `ElectronicBandStructure`. This produced wide `(1, N)` arrays with a bogus `spin_channel` (the SCF-snapshot index), one entry per SCF step. The archive browser crashed rendering these (FAIRmat-NFDI/nomad-simulations#462), and they were semantically wrong — a plain SCF run has no band structure. This routes the data to `electronic_eigenvalues` instead.

## Scope

**Included**

- Drop the `electronic_band_structures` mapping, the `get_band_structures` transformer, and the `ElectronicBandStructure` mapping class.
- Populate `electronic_eigenvalues` instead. Fixes an annotation-key bug where `value`/`occupation` were registered under `text` rather than `TEXT_KEY` (`fhiaims_text`), so the sections were silently pruned.
- Attach the Hartree unit to the parsed eigenvalues (previously stored as raw joules, i.e. `~1e20 eV`).
- Set `spin_channel` from the real spin loop (left unset for spin-unpolarized runs).
- Collapse to the converged (last) SCF block: one `electronic_eigenvalues` section per output.
- Remove redundant legacy `text`-key annotations superseded by `TEXT_KEY`.
- Add a regression test.

**Out of scope**

- Parsing genuine band structures from FHI-aims `output band` / `band****.out` path files. The parser already detects the segments (`band_segment_points`), but reading the path eigenvalues is a separate feature and needs a fixture.
- Frontend renderer robustness for wide/degenerate 2D arrays (`nomad-FAIR` `visualizations.js`) — tracked separately.

## Context & Links

- Fixes FAIRmat-NFDI/nomad-simulations#462.

## Reviewer Notes

Verified on `tests/data/fhiaims/Si_geomopt`:

| | before | after |
|---|---|---|
| `electronic_band_structures` / output | 2-3 (`spin_channel` 0,1,2) | 0 |
| `electronic_eigenvalues` / output | 0 (pruned) | 1 |
| shape | `(1, N)` | `(1, 20)` = `[n_kpoints, n_levels]` |
| state-1 value | `~ -4e20 eV` | `~ -1774 eV` |

## Status

- [x] Draft / In progress
- [ ] Ready for review

## Breaking Changes

- [x] None (removes malformed data; SCF runs produced no valid band structure)

## Testing / Validation

- [x] Unit tests (new regression test; existing FHI-aims / octopus / wannier90 suites pass)
